### PR TITLE
Add support for including MANIFEST.in

### DIFF
--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -37,7 +37,7 @@ exports.ApiRepo = ApiRepo;
 exports.GOOGLE_APIS_REPO_ZIP = GOOGLE_APIS_REPO_ZIP;
 
 var GOOGLE_APIS_REPO_ZIP =
-    'https://github.com/google/googleapis/archive/master.zip';
+    'https://github.com/googleapis/googleapis/archive/master.zip';
 
 var DEFAULT_LANGUAGES = [
   'go',

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -75,11 +75,13 @@ var settings = {
   'python': {
     'copyables': [
       'PUBLISHING.rst',
+      'MANIFEST.in',
       '../LICENSE'
     ],
     'templates': [
       'README.rst.mustache',
-      'setup.py.mustache'
+      'setup.py.mustache',
+      'requirements.txt.mustache'
     ]
   },
   'ruby': {
@@ -128,6 +130,13 @@ function makeGolangPackage(opts, done) {
   });
 }
 
+function removeMustacheExt(filePath) {
+  var extIndex = filePath.lastIndexOf('.mustache');
+  if (extIndex === -1) {
+    return filePath;
+  }
+  return filePath.slice(0, extIndex);
+}
 
 /**
  * makePythonPackage creates a new python package.
@@ -206,13 +215,7 @@ function makePythonPackage(opts, done) {
   var packageName = opts.packageInfo.api.name + '-' +
       opts.packageInfo.api.version;
   opts.templates.forEach(function(f) {
-    var dstBase = f;
-    if (dstBase === 'setup.py.mustache') {
-      dstBase = 'setup.py';
-    }
-    if (dstBase === 'README.rst.mustache') {
-      dstBase = 'README.rst';
-    }
+    var dstBase = removeMustacheExt(f);
     var tmpl = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, dstBase);
     tasks.push(expand.bind(null, tmpl, dst, opts.packageInfo));
@@ -254,10 +257,7 @@ function makeJavaPackage(opts, done) {
   var packageName = opts.packageInfo.api.name + '-' +
       opts.packageInfo.api.version;
   opts.templates.forEach(function(f) {
-    var dstBase = f;
-    if (dstBase === 'build.gradle.mustache') {
-      dstBase = 'build.gradle';
-    }
+    var dstBase = removeMustacheExt(f);
     var tmpl = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, dstBase);
     tasks.push(expand.bind(null, tmpl, dst, opts.packageInfo));
@@ -298,13 +298,7 @@ function makeNodejsPackage(opts, done) {
   var packageName = opts.packageInfo.api.name + '-' +
       opts.packageInfo.api.version;
   opts.templates.forEach(function(f) {
-    var dstBase = f;
-    if (dstBase === 'package.json.mustache') {
-      dstBase = 'package.json';
-    }
-    if (dstBase === 'README.md.mustache') {
-      dstBase = 'README.md';
-    }
+    var dstBase = removeMustacheExt(f);
     var tmpl = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, dstBase);
     tasks.push(expand.bind(null, tmpl, dst, opts.packageInfo));
@@ -430,8 +424,12 @@ function expand(template, dst, params, done) {
   // renders and saves the output file
   var render = function render(err, renderable) {
     if (err) {
-      console.error('Expansion of %s to %s failed with %s', template, dst, err);
-      done(err);
+      if (err.code === "ENOENT") {
+        done();  /* It's OK for templates not to present in some cases */
+      } else {
+        console.error('Expansion of %s to %s failed with %s', template, dst, err);
+        done(err);
+      }
     } else {
       fs.writeFile(dst, Mustache.render(renderable, params), done);
     }

--- a/templates/commonpb/python/MANIFEST.in
+++ b/templates/commonpb/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/templates/python/MANIFEST.in
+++ b/templates/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -125,7 +125,7 @@ describe('ApiRepo', function() {
             throw new Error('should not be reached');
           });
           repo.on('ready', function() {
-            repo.buildPackages('pubsub', 'v1beta2', passesOn(done));
+            repo.buildPackages('pubsub', 'v1', passesOn(done));
           });
           repo.setUp();
         });

--- a/test/packager.js
+++ b/test/packager.js
@@ -234,7 +234,8 @@ describe('the python package builder', function() {
       top: path.join(top, 'python')
     }, templateDirs.python);
     var copies = [
-      'python/PUBLISHING.rst'
+      'python/PUBLISHING.rst',
+      'python/MANIFEST.in'
     ];
     var checkCopies = function checkCopies(next) {
       var checkACopy = genCopyCompareFunc(top);


### PR DESCRIPTION
- Python packages should incorporate a MANIFEST.in and optionally requirements.txt; this
adds support for that.

Also, simplifies the code for specifying what templates need to be
transformed per-language by allowing them be absent.  If a template is
specified for a language, but is not present, it is skipped.

Change-Id: I77ad8dc93337799f0c0ddeee82ddee51575aefbe