### PR TITLE
Specify target JDK version for Java

### DIFF
--- a/templates/java/build.gradle.mustache
+++ b/templates/java/build.gradle.mustache
@@ -6,6 +6,9 @@ description = 'GRPC library for service {{api.name}}-{{api.version}}'
 group = "com.google.apis"
 version = "{{api.name}}-{{api.version}}-SNAPSHOT"
 
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
+
 repositories {
   mavenCentral()
   mavenLocal()


### PR DESCRIPTION
This prevents needing to use JDK 6/7 to build. You can use JDK 8 to
compile and it will still work with older JREs.

This is untested, because after installing node, npm, and dependencies I got this error when trying to run. After some more fiddling, I gave up.
```
/home/ejona/clients/packman/lib/api_repo.js:345
          var src = path.join(this.repoDir, protoPath),
                                  ^
TypeError: Cannot read property 'repoDir' of undefined
```

@tbetbetbe 