### PR TITLE
Adds support for java packages with compiled code

### DIFF
--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -195,6 +195,17 @@ var parseArgs = function parseArgs() {
     }
   );
   cli.addArgument(
+    [ '--experimental_alt_java' ],
+    {
+      defaultValue: false,
+      action: 'storeTrue',
+      help: 'When set indicates that the alternate build is used for java.\n'
+            + ' This ensures that the generated gradle files will build packages'
+            + ' that contain compiled java classes rather the protobuf source.',
+      dest: 'altJava'
+    }
+  );
+  cli.addArgument(
     [ '--override_plugins' ],
     {
       action: 'append',

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -187,6 +187,7 @@ ApiRepo.prototype.buildPackages =
       var tasks = [];
       var that = this;
       var done = this._wrap_done(opt_done);
+      var altJava = this.opts.altJava;
 
       var templateInfo = rootTemplateDir(defaultTemplateInfo, this.templateRoot);
       this.languages.forEach(function(l) {
@@ -194,6 +195,7 @@ ApiRepo.prototype.buildPackages =
         if (packager[l]) {
           var buildAPackage = function buildAPackage(generated, next) {
             var opts = _.merge({
+              'altJava': altJava,
               'top': path.join(that.outDir, l),
               'packageInfo': that.packageInfo,
               'generated': generated
@@ -338,6 +340,7 @@ ApiRepo.prototype.buildCommonProtoPkgs =
     function buildCommonProtoPkgs(opt_done) {
       var tasks = [];
       var that = this;
+      var altJava = this.opts.altJava;
       var done = this._wrap_done(opt_done);
 
       var templateRoot = path.join(__dirname, '..', 'templates', 'commonpb');
@@ -357,6 +360,7 @@ ApiRepo.prototype.buildCommonProtoPkgs =
         if (packager[l]) {
           var buildAPackage = function buildAPackage(allGenerated, done) {
             var opts = _.merge({
+              'altJava': altJava,
               'buildCommonProtos': true,
               'top': path.join(that.outDir, l),
               'packageInfo': that.packageInfo,

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -50,6 +50,7 @@ var settings = {
     ],
     'templates': [
       'build.gradle.mustache',
+      'build-alt.gradle.mustache',
       'settings.gradle.mustache'
     ]
   },
@@ -296,6 +297,16 @@ function makeJavaPackage(opts, done) {
   // Move the expanded files to the top-level dir.
   opts.templates.forEach(function(f) {
     var dstBase = removeMustacheExt(f);
+    if (opts.altJava) {
+      if (dstBase === 'build.gradle') {
+        return;  // don't expand the normal build.gradle
+      }
+      if (dstBase === 'build-alt.gradle') {
+        dstBase = 'build.gradle';  // Use the alt build.gradle
+      }
+    } else if (dstBase === 'build-alt.gradle') {
+      return;  // normally, don't expand the alt build.gradle
+    }
     var tmpl = path.join(opts.templateDir, f)
     , dst = path.join(opts.top, dstBase);
     tasks.push(expand(tmpl, dst, opts.packageInfo));

--- a/templates/commonpb/java/build-alt.gradle.mustache
+++ b/templates/commonpb/java/build-alt.gradle.mustache
@@ -1,6 +1,14 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.6' }
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'com.google.protobuf'
 
 description = 'Common protobufs used in Google APIs'
 group = "io.gapi"
@@ -19,6 +27,15 @@ repositories {
 
 dependencies {
   compile "com.google.protobuf:protobuf-java:3.0.0-beta-2"
+}
+
+protobuf {
+  protoc {
+    // The version of protoc must match protobuf-java. If you don't depend on
+    // protobuf-java directly, you will be transitively depending on the
+    // protobuf-java version that grpc depends on.
+    artifact = "com.google.protobuf:protoc:3.0.0-beta-2"
+  }
 }
 
 task javadocJar(type: Jar) {

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -1,24 +1,44 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.6' }
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'com.google.protobuf'
 
-description = 'Common protobufs used in Google APIs'
+description = 'GRPC library for service {{api.name}}-{{api.version}}'
 group = "io.gapi"
-version = "0.0.0-SNAPSHOT"
-// version = "{{api.semantic_version}}-SNAPSHOT"
-// TODO: switch to this once all common protos are actually public
+version = "{{api.semantic_version}}-SNAPSHOT"
 // TODO: use a flag to determine whether to produce a release or a snapshot
-
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
+def tmpSnapshotRepo = "http://104.197.230.53:8081/nexus/content/repositories/snapshots/"
 
 repositories {
   mavenCentral()
   mavenLocal()
+  maven {
+    // Private maven repo.  Temporary, until googleapis-common-protos is published
+    url tmpSnapshotRepo
+  }
 }
 
 dependencies {
   compile "com.google.protobuf:protobuf-java:3.0.0-beta-2"
+  compile "io.gapi:googleapis-common-protos:0.0.0-SNAPSHOT"
+}
+
+protobuf {
+  protoc {
+    // The version of protoc must match protobuf-java. If you don't depend on
+    // protobuf-java directly, you will be transitively depending on the
+    // protobuf-java version that grpc depends on.
+    artifact = "com.google.protobuf:protoc:3.0.0-beta-2"
+  }
 }
 
 task javadocJar(type: Jar) {
@@ -41,8 +61,6 @@ signing {
 }
 
 uploadArchives.repositories.mavenDeployer {
- // url to the snapshot repository of a private maven repo.
-  def tmpSnapshotRepo = "http://104.197.230.53:8081/nexus/content/repositories/snapshots/"
   beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
   String stagingUrl
     if (rootProject.hasProperty('repositoryId')) {
@@ -57,11 +75,7 @@ uploadArchives.repositories.mavenDeployer {
     }
   }
   repository(url: stagingUrl, configureAuth)
-  snapshotRepository(url: tmpSnapshotRepo) {
-    authentication(userName: privateOssrhUsername, password: privateOssrhPassword)
-  }
-
-  // snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
+  snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
 }
 
 [
@@ -69,7 +83,7 @@ uploadArchives.repositories.mavenDeployer {
   uploadArchives.repositories.mavenDeployer,
 ]*.pom { pom ->
   pom.project {
-    name "io.gapi:{{api.name}}"
+    name "io.gapi:{{api.name}}-{{api.version}}"
     description project.description
     url '{{{api.homepage}}}'
 
@@ -82,8 +96,8 @@ uploadArchives.repositories.mavenDeployer {
     licenses {
       license {
         name '{{api.license}}'
-        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-     }
+        url '{{{api.license.url}}}'
+      }
     }
 
     developers {


### PR DESCRIPTION
Fixes #20

- it adds experimental_alt_java flag to gen-api-package that modifies
java package generation

- normally, the generated gradle file builds a package that only
contains protos

- when the flag is set, the generated gradle file builds a package from
the java source generated running the protoc

Change-Id: Iae50a2192595774502ad368196de507ad90e437a