### PR TITLE
Update to mention new auth method

### DIFF
--- a/templates/gax/python/README.rst.mustache
+++ b/templates/gax/python/README.rst.mustache
@@ -25,9 +25,18 @@ Once done, you can then run the following command in your terminal:
 
 .. code-block:: console
 
+    $ gcloud beta auth application-default login
+
+or
+
+.. code-block:: console
+
     $ gcloud auth login
 
+Please see `gcloud beta auth application-default login`_ document for the difference between these commands.
+
 .. _Google Cloud SDK: https://cloud.google.com/sdk/
+.. _gcloud beta auth application-default login: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
 
 
 Installation

--- a/templates/gax/python/docs/starting.rst.mustache
+++ b/templates/gax/python/docs/starting.rst.mustache
@@ -54,10 +54,19 @@ Once done, you can then run the following command in your terminal:
 
 .. code-block:: console
 
+    $ gcloud beta auth application-default login
+
+or
+
+.. code-block:: console
+
     $ gcloud auth login
 
-.. _Google Cloud SDK: https://cloud.google.com/sdk/
+Please see `gcloud beta auth application-default login`_ document for the difference between these commands.
 
+.. _Google Cloud SDK: https://cloud.google.com/sdk/
+.. _gcloud beta auth application-default login: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
+.. code-block:: console
 
 At this point you are all set to continue.
 

--- a/templates/gax/ruby/README.md.mustache
+++ b/templates/gax/ruby/README.md.mustache
@@ -21,9 +21,16 @@ Setup Authentication
 To authenticate all your API calls, first install and setup the [`Google Cloud SDK`][].
 Once done, you can then run the following command in your terminal:
 
+    $ gcloud beta auth application-default login
+
+or
+
     $ gcloud auth login
 
+Please see [[gcloud beta auth application-default login][] document for the difference between these commands.
+
 [Google Cloud SDK]: https://cloud.google.com/sdk/
+[gcloud beta auth application-default login]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
 
 
 Installation


### PR DESCRIPTION
Reported to recommend gcloud beta auth application-default login
rather than gcloud auth login. Considering the beta status,
I think we should mention both.

This fixes #28