### PR TITLE
Update the version of gradle used

### DIFF
--- a/templates/commonpb/java/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/commonpb/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 02 11:58:09 PDT 2015
+#Mon May 02 22:27:46 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip

--- a/templates/java/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 02 11:58:09 PDT 2015
+#Mon May 02 22:26:16 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip


### PR DESCRIPTION
Change-Id: Ifb52f17ed1e527afa7232c4a5d9aa9577a3e1024

This is necessary to use the latest version of the protobuf-gradle plugin when doing experiment java builds.