### PR TITLE
Ruby: list the core API classes in README.md

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -18,8 +18,8 @@
 author: Google Inc
 description: a grpc-based api
 email: googleapis-packages@google.com
-github_user_uri: https://github.com/google
-homepage: https://github.com/google/googleapis
+github_user_uri: https://github.com/googleapis
+homepage: https://github.com/googleapis/googleapis
 license: Apache-2.0
 semver:
   go: '0.6.0'
@@ -27,5 +27,5 @@ semver:
   java: '0.6.0'
   nodejs: '0.6.0'
   python: '1.0.18'
-  ruby: '0.6.0'
+  ruby: '0.6.3'
   php: '0.6.0'

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -423,48 +423,87 @@ function makeObjcPackage(opts, done) {
  * @param {function} done is called once the package is created.
  */
 function makeRubyPackage(opts, done) {
+  /**
+   * Collect the primary class names for the (gax) API package, and invoke done
+   * with the list of objects whose 'name' is the name of the ruby class and
+   * 'path' is the pathname in YARD-style document.
+   * The result will be referred from README.md file of the generated document,
+   * so that the users can quickly find the primary entry points of the package.
+   */
+  function collectApiClasses(done) {
+    var apiClasses = [];
+    function underscoreToCamelCase(str) {
+      return _.map(str.split('_'), function(segment) {
+        return segment.charAt(0).toUpperCase() + segment.slice(1);
+      }).join('');
+    }
+    function rbFileToData(rbFile) {
+      var pathComponents = _.map(
+          rbFile.replace(/\.rb$/, '').split('/'), underscoreToCamelCase);
+      return {'name': pathComponents.join('::'),
+              'path': pathComponents.join('/')};
+    }
+    glob.glob("**/*.rb", {cwd: path.join(opts.top, 'lib'),
+                          ignore: "**/doc/**/*.rb"},
+              function(err, rbFiles) {
+                if (err) {
+                  done(err);
+                } else {
+                  done(null, _.map(rbFiles, rbFileToData));
+                }
+              });
+  }
+
   opts = _.merge({}, settings.ruby, opts);
   fs.mkdirsSync(path.join(opts.top, 'lib'));
-  var tasks = [];
 
-  // Move the generated files to the lib dir.
-  opts.generated = opts.generated || [];
-  opts.generated.forEach(function(f) {
-    var src = path.join(opts.top, f)
-    , dst = path.join(opts.top, 'lib', f);
-    tasks.push(fs.move.bind(fs, src, dst));
-  });
-
-  // Move copyable files to the top-level dir.
-  opts.copyables.forEach(function(f) {
-    var src = path.join(opts.templateDir, f)
-    , dst = path.join(opts.top, f);
-    if (f === '../LICENSE') {
-      dst = path.join(opts.top, 'LICENSE');
+  collectApiClasses(function(err, apiClasses) {
+    if (err) {
+      done(err);
+      return;
     }
-    tasks.push(checkedCopy(src, dst));
-  });
+    var tasks = [];
+    opts.packageInfo.api.apiClasses = apiClasses;
 
-  // Move the expanded files to the top-level dir.
-  var packageName = pkgName(opts.packageInfo);
-  opts.templates.forEach(function(f) {
-    var dstBase = removeMustacheExt(f);
-    if (dstBase === 'gemspec') {
-      dstBase = packageName + '.gemspec';
-    }
-    var tmpl = path.join(opts.templateDir, f)
-    , dst = path.join(opts.top, dstBase);
-    tasks.push(ifExists(tmpl, expand(tmpl, dst, opts.packageInfo)));
-  });
+    // Move the generated files to the lib dir.
+    opts.generated = opts.generated || [];
+    opts.generated.forEach(function(f) {
+      var src = path.join(opts.top, f)
+      , dst = path.join(opts.top, 'lib', f);
+      tasks.push(fs.move.bind(fs, src, dst));
+    });
 
-  async.parallel(tasks, function(err) {
-    if (!err && opts.copyables.indexOf('PUBLISHING.md') != -1) {
-      console.log('The ruby package', packageName, 'was created in',
-                  opts.top);
-      console.log('To publish it, read', path.join(opts.top, 'PUBLISHING.md'),
-                  'for the next steps');
-    }
-    done(err);
+    // Move copyable files to the top-level dir.
+    opts.copyables.forEach(function(f) {
+      var src = path.join(opts.templateDir, f)
+      , dst = path.join(opts.top, f);
+      if (f === '../LICENSE') {
+        dst = path.join(opts.top, 'LICENSE');
+      }
+      tasks.push(checkedCopy(src, dst));
+    });
+
+    // Move the expanded files to the top-level dir.
+    var packageName = pkgName(opts.packageInfo);
+    opts.templates.forEach(function(f) {
+      var dstBase = removeMustacheExt(f);
+      if (dstBase === 'gemspec') {
+        dstBase = packageName + '.gemspec';
+      }
+      var tmpl = path.join(opts.templateDir, f)
+      , dst = path.join(opts.top, dstBase);
+      tasks.push(ifExists(tmpl, expand(tmpl, dst, opts.packageInfo)));
+    });
+
+    async.parallel(tasks, function(err) {
+      if (!err && opts.copyables.indexOf('PUBLISHING.md') != -1) {
+        console.log('The ruby package', packageName, 'was created in',
+                    opts.top);
+        console.log('To publish it, read', path.join(opts.top, 'PUBLISHING.md'),
+                    'for the next steps');
+      }
+      done(err);
+    });
   });
 }
 

--- a/templates/gax/ruby/README.md.mustache
+++ b/templates/gax/ruby/README.md.mustache
@@ -2,23 +2,29 @@ GAX library for the Google {{api.titlename}} API
 =================================================
 
 {{api.name}}-{{api.version}} uses [Google API extensions][google-gax] to provide an
-easy-to-use client library for the [`Google {{api.titlename}} API`][] ({{api.version}}) defined in the [googleapis][] git repository
+easy-to-use client library for the [Google {{api.titlename}} API][] ({{api.version}}) defined in the [googleapis][] git repository
 
 
 [googleapis]: https://github.com/googleapis/googleapis/tree/master/google/{{api.path}}/{{api.version}}
 [google-gax]: https://github.com/googleapis/gax-ruby
-[`Google {{api.titlename}} API`]: https://developers.google.com/apis-explorer/#p/{{api.shortname}}/{{api.version}}/
+[Google {{api.titlename}} API]: https://developers.google.com/apis-explorer/#p/{{api.shortname}}/{{api.version}}/
 
 Getting started
 ---------------
 
-{{api.name}}-{{api.version}} will allow you to connect to the [`Google {{api.title}} API`][] and access all its methods. In order to achieve so you need to set up authentication as well as install the library locally.
+{{api.name}}-{{api.version}} will allow you to connect to the [Google {{api.titlename}} API][] and access all its methods. See the following classes for the actual API access.
+
+{{#api.apiClasses}}
+- [{{name}}](http://www.rubydoc.info/gems/{{api.name}}-{{api.version}}/{{api.semantic_version}}/{{path}})
+{{/api.apiClasses}}
+
+In order to achieve so you need to set up authentication as well as install the library locally.
 
 
 Setup Authentication
 --------------------
 
-To authenticate all your API calls, first install and setup the [`Google Cloud SDK`][].
+To authenticate all your API calls, first install and setup the [Google Cloud SDK][].
 Once done, you can then run the following command in your terminal:
 
     $ gcloud beta auth application-default login


### PR DESCRIPTION
Because Gapic/Ruby now generates 'doc' files, the generated
package document contains tons of classes and it's hard for
users to find where they can start.

This patch scans the files under lib/ and generates the list
of core classes. This logic assumes that Gapic/Ruby generates
the 'doc' files under a directory 'doc/'.

Upgrading to 0.6.3 considering I've uploaded some packages
to 0.6.2 in rubygems.org.

Fixes #32