### PR TITLE
Introduce a new type of grpc client for nodejs

### DIFF
--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -206,6 +206,18 @@ var parseArgs = function parseArgs() {
     }
   );
   cli.addArgument(
+    [ '--nodejs_use_pbjs' ],
+    {
+      defaultValue: false,
+      action: 'storeTrue',
+      help: 'When set, the nodejs grpc client is generated with the json data\n'
+            + ' generated from pbjs. Otherwise the client bundles .proto\n'
+            + ' files. Note that pbjs-based client does not work currently\n'
+            + ' (see https://github.com/googleapis/packman/issues/35).',
+      dest: 'nodejsUsePbjs'
+    }
+  );
+  cli.addArgument(
     [ '--override_plugins' ],
     {
       action: 'append',

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -53,6 +53,9 @@ protobuf:
     version: '3.0.0b3'
   ruby:
     version: '3.0.0.alpha.5.0.5.1'
+  nodejs:
+    # This is the version of ProtoBuf.js.
+    version: '5.0.1'
 
 googleapis_common_protos:
   python:

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -391,51 +391,6 @@ ApiRepo.prototype.buildCommonProtoPkgs =
       async.parallel(tasks, done);
     };
 
-function buildFilesMap(filesMap, includePaths, filePath) {
-  for (var i = 0; i < includePaths.length; ++i) {
-    if (filePath.indexOf(includePaths[i]) == 0) {
-      var src = includePaths[i];
-      filesMap[filePath] = filePath.slice(src.length + 1);
-      return;
-    }
-  }
-}
-
-function copyProtoFiles(filesMap, outDir, done) {
-  async.waterfall(_.map(filesMap, function(dstBase, fileName) {
-    return function copyAProto(next) {
-      var outFile = path.join(outDir, dstBase);
-      fs.mkdirsSync(path.dirname(outFile));
-      fs.copy(fileName, outFile, function(err) {
-        next(err);
-      });
-    };
-  }), done);
-}
-
-function collectProtoDeps(protoFile, includePath, done) {
-  var deps = tmp.fileSync();
-  var desc = tmp.fileSync();
-  var args = ['--dependency_out=' + deps.name, '-o', desc.name];
-  if (includePath) {
-    includePath.forEach(function(ipath) {
-      args.push('-I', ipath);
-    });
-  }
-  args.push(protoFile);
-  child_process.execFile('protoc', args, {}, function(err) {
-    if (err) {
-      done(err);
-    }
-    fs.readFile(deps.name, 'utf-8', function(err, data) {
-      if (err) {
-        done(err);
-      }
-      done(null, data.replace(/^\s+/, '').replace(/\\/mg, '').split(/\s+/m));
-    });
-  });
-}
-
 /**
  * _buildProtos builds the protos for named api and version in the target languages.
  *
@@ -481,7 +436,12 @@ ApiRepo.prototype._buildProtos =
         }.bind(this);
         this._findProtos(name, version, findOutputs, copyJavaPb);
       } else if (language === 'nodejs') {
-        function makeProtoBasedNodeModule(fullPathProtos, includePath) {
+        /**
+         * makeProtoBasedNodeModule finds the required .proto files for the API
+         * and copies them into the output directory.
+         */
+        var makeProtoBasedNodeModule =
+            function makeProtoBasedNodeModule(fullPathProtos, includePath) {
           var tasks = [function(next) { next(null, {}); }];
           tasks.push.apply(tasks, _.map(fullPathProtos, function(proto) {
             return function collectProtoTask(filesMap, next) {
@@ -490,7 +450,8 @@ ApiRepo.prototype._buildProtos =
                   next(err);
                   return;
                 }
-                deps.forEach(buildFilesMap.bind(null, filesMap, includePath));
+                deps.forEach(
+                    buildDependencyFilesMap.bind(null, filesMap, includePath));
                 next(null, filesMap);
               });
             };
@@ -499,7 +460,7 @@ ApiRepo.prototype._buildProtos =
             var outDir = path.join(langTopDir, 'proto');
             copyProtoFiles(filesMap, outDir, findOutputs);
           });
-        }
+        };
         /**
          * makeNodeModule writes a commonJS module containing all the protos
          * used by service.
@@ -538,6 +499,60 @@ ApiRepo.prototype._buildProtos =
       }
     };
 
+/**
+ * Process a filePath of dependency .proto into the mapping of
+ * source files to the destination.
+ */
+function buildDependencyFilesMap(filesMap, includePaths, filePath) {
+  for (var i = 0; i < includePaths.length; ++i) {
+    if (filePath.indexOf(includePaths[i]) === 0) {
+      var src = includePaths[i];
+      filesMap[filePath] = filePath.slice(src.length + 1);
+      return;
+    }
+  }
+}
+
+/**
+ * Copy the files listed in from filesMap to output directory.
+ */
+function copyProtoFiles(filesMap, outDir, done) {
+  async.waterfall(_.map(filesMap, function(dstBase, fileName) {
+    return function copyAProto(next) {
+      var outFile = path.join(outDir, dstBase);
+      fs.mkdirsSync(path.dirname(outFile));
+      fs.copy(fileName, outFile, function(err) {
+        next(err);
+      });
+    };
+  }), done);
+}
+
+/**
+ * Collect required files from a .proto file.
+ */
+function collectProtoDeps(protoFile, includePath, done) {
+  var deps = tmp.fileSync();
+  var desc = tmp.fileSync();
+  var args = ['--dependency_out=' + deps.name, '-o', desc.name];
+  if (includePath) {
+    includePath.forEach(function(ipath) {
+      args.push('-I', ipath);
+    });
+  }
+  args.push(protoFile);
+  child_process.execFile('protoc', args, {}, function(err) {
+    if (err) {
+      done(err);
+    }
+    fs.readFile(deps.name, 'utf-8', function(err, data) {
+      if (err) {
+        done(err);
+      }
+      done(null, data.replace(/^\s+/, '').replace(/\\/mg, '').split(/\s+/m));
+    });
+  });
+}
 
 /**
  * Defines the default plugin name. Only languages where the default plugin

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -474,8 +474,13 @@ ApiRepo.prototype._buildProtos =
          */
         var makeProtoBasedNodeModule =
             function makeProtoBasedNodeModule(fullPathProtos, includePath) {
+          // filesMap keeps the mapping for proto files from the source file
+          // locaiton to the destination.
+          var filesMap = {};
+          var outDir = path.join(langTopDir, 'proto');
+
           /** Add an entry for filePath to filesMap. */
-          function addToFilesMap(filesMap, outDir, filePath) {
+          function addToFilesMap(filePath) {
             if (filePath in filesMap) {
               return;
             }
@@ -488,11 +493,6 @@ ApiRepo.prototype._buildProtos =
             }
           }
 
-          // filesMap keeps the mapping for proto files from the source file
-          // locaiton to the destination.
-          var filesMap = {};
-          var outDir = path.join(langTopDir, 'proto');
-
           var tasks = _.map(fullPathProtos, function(proto) {
             return function collectProtoTask(next) {
               collectProtoDeps(proto, includePath, function(err, deps) {
@@ -501,7 +501,7 @@ ApiRepo.prototype._buildProtos =
                   return;
                 }
                 // Building filesMap contents for the dependencies.
-                deps.forEach(addToFilesMap.bind(null, filesMap, outDir));
+                deps.forEach(addToFilesMap);
                 next();
               });
             };

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -442,23 +442,43 @@ ApiRepo.prototype._buildProtos =
          */
         var makeProtoBasedNodeModule =
             function makeProtoBasedNodeModule(fullPathProtos, includePath) {
-          var tasks = [function(next) { next(null, {}); }];
-          tasks.push.apply(tasks, _.map(fullPathProtos, function(proto) {
-            return function collectProtoTask(filesMap, next) {
+          /** Add an entry for filePath to filesMap. */
+          function addToFilesMap(filePath) {
+            if (filePath in filesMap) {
+              return;
+            }
+            for (var i = 0; i < includePath.length; ++i) {
+              if (filePath.indexOf(includePath[i]) === 0) {
+                var relativePath = filePath.slice(includePath[i].length + 1);
+                filesMap[filePath] = path.join(outDir, relativePath);
+                return;
+              }
+            }
+          }
+
+          // filesMap keeps the mapping for proto files from the source file
+          // locaiton to the destination.
+          var filesMap = {};
+          var outDir = path.join(langTopDir, 'proto');
+
+          var tasks = _.map(fullPathProtos, function(proto) {
+            return function collectProtoTask(next) {
               collectProtoDeps(proto, includePath, function(err, deps) {
                 if (err) {
                   next(err);
                   return;
                 }
-                deps.forEach(
-                    buildDependencyFilesMap.bind(null, filesMap, includePath));
-                next(null, filesMap);
+                // Building filesMap contents for the dependencies.
+                deps.forEach(addToFilesMap);
+                next();
               });
             };
-          }));
-          async.waterfall(tasks, function(err, filesMap) {
-            var outDir = path.join(langTopDir, 'proto');
-            copyProtoFiles(filesMap, outDir, findOutputs);
+          });
+          async.waterfall(tasks, function(err) {
+            async.forEachOf(filesMap, function(dst, src, next) {
+              fs.mkdirsSync(path.dirname(dst));
+              fs.copy(src, dst, next);
+            }, findOutputs);
           });
         };
         /**
@@ -500,36 +520,9 @@ ApiRepo.prototype._buildProtos =
     };
 
 /**
- * Process a filePath of dependency .proto into the mapping of
- * source files to the destination.
- */
-function buildDependencyFilesMap(filesMap, includePaths, filePath) {
-  for (var i = 0; i < includePaths.length; ++i) {
-    if (filePath.indexOf(includePaths[i]) === 0) {
-      var src = includePaths[i];
-      filesMap[filePath] = filePath.slice(src.length + 1);
-      return;
-    }
-  }
-}
-
-/**
- * Copy the files listed in from filesMap to output directory.
- */
-function copyProtoFiles(filesMap, outDir, done) {
-  async.waterfall(_.map(filesMap, function(dstBase, fileName) {
-    return function copyAProto(next) {
-      var outFile = path.join(outDir, dstBase);
-      fs.mkdirsSync(path.dirname(outFile));
-      fs.copy(fileName, outFile, function(err) {
-        next(err);
-      });
-    };
-  }), done);
-}
-
-/**
- * Collect required files from a .proto file.
+ * Collect the required files from a .proto file. 'done' will be
+ * called with the list of file name within the includePath when
+ * the task has finished.
  */
 function collectProtoDeps(protoFile, includePath, done) {
   var deps = tmp.fileSync();
@@ -541,6 +534,8 @@ function collectProtoDeps(protoFile, includePath, done) {
     });
   }
   args.push(protoFile);
+  // Invokes protoc with --dependency_out to generate the dependency
+  // proto files.
   child_process.execFile('protoc', args, {}, function(err) {
     if (err) {
       done(err);
@@ -549,7 +544,10 @@ function collectProtoDeps(protoFile, includePath, done) {
       if (err) {
         done(err);
       }
-      done(null, data.replace(/^\s+/, '').replace(/\\/mg, '').split(/\s+/m));
+      // protoc generates the dependencies 'in the format expected by make',
+      // that is -- separated by spaces, and newline character is escaped by
+      // a backslash.
+      done(null, data.replace(/^\s+/, '').replace(/\\\n/mg, ' ').split(/\s+/m));
     });
   });
 }

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -205,7 +205,6 @@ ApiRepo.prototype.buildPackages =
               'generated': generated
             }, templateInfo[l]);
             if (l == 'nodejs' && !that.opts.nodejsUsePbjs) {
-              opts.templates = ['service.js.mustache'];
               opts.packageInfo.protoFiles = _.filter(generated, function(file) {
                 return file.match(/\.proto$/);
               });
@@ -392,6 +391,39 @@ ApiRepo.prototype.buildCommonProtoPkgs =
     };
 
 /**
+ * Collect the required files from a .proto file. 'done' will be
+ * called with the list of file name within the includePath when
+ * the task has finished.
+ */
+function collectProtoDeps(protoFile, includePath, done) {
+  var deps = tmp.fileSync();
+  var desc = tmp.fileSync();
+  var args = ['--dependency_out=' + deps.name, '-o', desc.name];
+  if (includePath) {
+    includePath.forEach(function(ipath) {
+      args.push('-I', ipath);
+    });
+  }
+  args.push(protoFile);
+  // Invokes protoc with --dependency_out to generate the dependency
+  // proto files.
+  child_process.execFile('protoc', args, {}, function(err) {
+    if (err) {
+      done(err);
+    }
+    fs.readFile(deps.name, 'utf-8', function(err, data) {
+      if (err) {
+        done(err);
+      }
+      // protoc generates the dependencies 'in the format expected by make',
+      // that is -- separated by spaces, and newline character is escaped by
+      // a backslash.
+      done(null, data.replace(/^\s+/, '').replace(/\\\n/mg, ' ').split(/\s+/m));
+    });
+  });
+}
+
+/**
  * _buildProtos builds the protos for named api and version in the target languages.
  *
  * @param {string} name the api name
@@ -443,7 +475,7 @@ ApiRepo.prototype._buildProtos =
         var makeProtoBasedNodeModule =
             function makeProtoBasedNodeModule(fullPathProtos, includePath) {
           /** Add an entry for filePath to filesMap. */
-          function addToFilesMap(filePath) {
+          function addToFilesMap(filesMap, outDir, filePath) {
             if (filePath in filesMap) {
               return;
             }
@@ -469,7 +501,7 @@ ApiRepo.prototype._buildProtos =
                   return;
                 }
                 // Building filesMap contents for the dependencies.
-                deps.forEach(addToFilesMap);
+                deps.forEach(addToFilesMap.bind(null, filesMap, outDir));
                 next();
               });
             };
@@ -518,39 +550,6 @@ ApiRepo.prototype._buildProtos =
         this._findProtos(name, version, findOutputs, protoc);
       }
     };
-
-/**
- * Collect the required files from a .proto file. 'done' will be
- * called with the list of file name within the includePath when
- * the task has finished.
- */
-function collectProtoDeps(protoFile, includePath, done) {
-  var deps = tmp.fileSync();
-  var desc = tmp.fileSync();
-  var args = ['--dependency_out=' + deps.name, '-o', desc.name];
-  if (includePath) {
-    includePath.forEach(function(ipath) {
-      args.push('-I', ipath);
-    });
-  }
-  args.push(protoFile);
-  // Invokes protoc with --dependency_out to generate the dependency
-  // proto files.
-  child_process.execFile('protoc', args, {}, function(err) {
-    if (err) {
-      done(err);
-    }
-    fs.readFile(deps.name, 'utf-8', function(err, data) {
-      if (err) {
-        done(err);
-      }
-      // protoc generates the dependencies 'in the format expected by make',
-      // that is -- separated by spaces, and newline character is escaped by
-      // a backslash.
-      done(null, data.replace(/^\s+/, '').replace(/\\\n/mg, ' ').split(/\s+/m));
-    });
-  });
-}
 
 /**
  * Defines the default plugin name. Only languages where the default plugin

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -204,6 +204,13 @@ ApiRepo.prototype.buildPackages =
               'packageInfo': that.packageInfo,
               'generated': generated
             }, templateInfo[l]);
+            if (l == 'nodejs' && !that.opts.nodejsUsePbjs) {
+              opts.templates = ['service.js.mustache'];
+              opts.packageInfo.protoFiles = _.filter(generated, function(file) {
+                return file.match(/\.proto$/);
+              });
+              opts.packageInfo.nodejsUseProtos = true;
+            }
             var cleanName = name.replace('/', '-');
             opts.packageInfo.api.simplename = cleanName;
             opts.packageInfo.api.path = cleanName.replace('-', '/');
@@ -384,6 +391,51 @@ ApiRepo.prototype.buildCommonProtoPkgs =
       async.parallel(tasks, done);
     };
 
+function buildFilesMap(filesMap, includePaths, filePath) {
+  for (var i = 0; i < includePaths.length; ++i) {
+    if (filePath.indexOf(includePaths[i]) == 0) {
+      var src = includePaths[i];
+      filesMap[filePath] = filePath.slice(src.length + 1);
+      return;
+    }
+  }
+}
+
+function copyProtoFiles(filesMap, outDir, done) {
+  async.waterfall(_.map(filesMap, function(dstBase, fileName) {
+    return function copyAProto(next) {
+      var outFile = path.join(outDir, dstBase);
+      fs.mkdirsSync(path.dirname(outFile));
+      fs.copy(fileName, outFile, function(err) {
+        next(err);
+      });
+    };
+  }), done);
+}
+
+function collectProtoDeps(protoFile, includePath, done) {
+  var deps = tmp.fileSync();
+  var desc = tmp.fileSync();
+  var args = ['--dependency_out=' + deps.name, '-o', desc.name];
+  if (includePath) {
+    includePath.forEach(function(ipath) {
+      args.push('-I', ipath);
+    });
+  }
+  args.push(protoFile);
+  child_process.execFile('protoc', args, {}, function(err) {
+    if (err) {
+      done(err);
+    }
+    fs.readFile(deps.name, 'utf-8', function(err, data) {
+      if (err) {
+        done(err);
+      }
+      done(null, data.replace(/^\s+/, '').replace(/\\/mg, '').split(/\s+/m));
+    });
+  });
+}
+
 /**
  * _buildProtos builds the protos for named api and version in the target languages.
  *
@@ -429,6 +481,25 @@ ApiRepo.prototype._buildProtos =
         }.bind(this);
         this._findProtos(name, version, findOutputs, copyJavaPb);
       } else if (language === 'nodejs') {
+        function makeProtoBasedNodeModule(fullPathProtos, includePath) {
+          var tasks = [function(next) { next(null, {}); }];
+          tasks.push.apply(tasks, _.map(fullPathProtos, function(proto) {
+            return function collectProtoTask(filesMap, next) {
+              collectProtoDeps(proto, includePath, function(err, deps) {
+                if (err) {
+                  next(err);
+                  return;
+                }
+                deps.forEach(buildFilesMap.bind(null, filesMap, includePath));
+                next(null, filesMap);
+              });
+            };
+          }));
+          async.waterfall(tasks, function(err, filesMap) {
+            var outDir = path.join(langTopDir, 'proto');
+            copyProtoFiles(filesMap, outDir, findOutputs);
+          });
+        }
         /**
          * makeNodeModule writes a commonJS module containing all the protos
          * used by service.
@@ -443,6 +514,10 @@ ApiRepo.prototype._buildProtos =
           }.bind(this));
 
           var includePath = _.union(this.includePath, [this.repoDir]);
+          if (!this.opts.nodejsUsePbjs) {
+            makeProtoBasedNodeModule(fullPathProtos, includePath);
+            return;
+          }
           var opts = {
             root: that.repoDir,
             source: 'proto',

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -344,6 +344,9 @@ function makeNodejsPackage(opts, done) {
   opts = _.merge({}, settings.nodejs, opts);
   var tasks = [];
 
+  if (!opts.packageInfo.nodejsUsePbjs) {
+    opts.templates.push('service.js.mustache');
+  }
   // Move copyable files to the top-level dir.
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)

--- a/templates/nodejs/package.json.mustache
+++ b/templates/nodejs/package.json.mustache
@@ -7,12 +7,16 @@
   "license": "{{api.license}}",
   "dependencies": {
     "grpc": "^{{{dependencies.grpc.nodejs.version}}}",
+    "protobufjs": "^{{{dependencies.protobuf.nodejs.version}}}",
     "google-auth-library": "^{{{dependencies.auth.nodejs.version}}}"
   },
   "main": "index.js",
   "files": [
     "LICENSE",
     "index.js",
+{{#nodejsUseProtos}}
+    "proto/**/*",
+{{/nodejsUseProtos}}
     "service.js"
   ]
 }

--- a/templates/nodejs/service.js.mustache
+++ b/templates/nodejs/service.js.mustache
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var protobufjs = require('protobufjs');
+var path = require('path');
+var builder = protobufjs.newBuilder({});
+builder.importRoot = path.join(__dirname, 'proto');
+{{#protoFiles}}
+protobufjs.loadProtoFile(
+    path.join(__dirname, '{{{.}}}'),
+    builder);
+{{/protoFiles}}
+module.exports = builder.ns;

--- a/test/fixtures/proto-based/nodejs/README.md
+++ b/test/fixtures/proto-based/nodejs/README.md
@@ -1,0 +1,6 @@
+# gRPC library for Google's packager-v2 service
+
+packager-unittest-v2 contains the IDL-generated [grpc][] library for the service: `packager-v2` in the [googleapis][] repository.
+
+[googleapis]:https://github.com/google/googleapis
+[grpc]:http://www.grpc.io/docs/tutorials/basic/node.html

--- a/test/fixtures/proto-based/nodejs/package.json
+++ b/test/fixtures/proto-based/nodejs/package.json
@@ -14,6 +14,7 @@
   "files": [
     "LICENSE",
     "index.js",
+    "proto/**/*",
     "service.js"
   ]
 }

--- a/test/fixtures/proto-based/nodejs/service.js
+++ b/test/fixtures/proto-based/nodejs/service.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var protobufjs = require('protobufjs');
+var path = require('path');
+var builder = protobufjs.newBuilder({});
+builder.importRoot = path.join(__dirname, 'proto');
+protobufjs.loadProtoFile(
+    path.join(__dirname, 'proto/foo.proto'),
+    builder);
+protobufjs.loadProtoFile(
+    path.join(__dirname, 'proto/bar/baz.proto'),
+    builder);
+module.exports = builder.ns;

--- a/test/packager.js
+++ b/test/packager.js
@@ -368,6 +368,7 @@ describe('the nodejs package builder', function() {
       top: path.join(top, 'nodejs')
     }, templateDirs.nodejs);
     opts.packageInfo.nodejsUseProtos = true;
+    opts.packageInfo.protoFiles = ['proto/foo.proto', 'proto/bar/baz.proto'];
     var copies = [
       'nodejs/index.js',
       'nodejs/PUBLISHING.md'
@@ -379,6 +380,7 @@ describe('the nodejs package builder', function() {
     };
     var expanded = [
       'nodejs/package.json',
+      'nodejs/service.js',
       'nodejs/README.md'
     ];
     var compareWithFixture = genFixtureCompareFunc(top, ['proto-based']);

--- a/test/packager.js
+++ b/test/packager.js
@@ -82,9 +82,16 @@ function filesEqual(file1, file2, done) {
   });
 }
 
-function genFixtureCompareFunc(top) {
+function genFixtureCompareFunc(top, fixture_subdirs) {
+  var fixture_base = ['fixtures'];
+  if (fixture_subdirs) {
+    fixture_base.push.apply(fixture_base, fixture_subdirs);
+  }
   return function compareWithFixture(c) {
-    var want = path.join(__dirname, 'fixtures', c);
+    var pathargs = fixture_base.slice();
+    pathargs.unshift(__dirname);
+    pathargs.push(c);
+    var want = path.join.apply(null, pathargs);
     var got = path.join(top, c);
     return filesEqual.bind(null, want, got);
   };
@@ -115,6 +122,9 @@ var testPackageInfo = {
     protobuf: {
       objc: {
         version: '3.0.0-alpha-3'
+      },
+      nodejs: {
+        version: '5.0.1'
       }
     },
     googleapis_common_protos: {
@@ -323,6 +333,7 @@ describe('the nodejs package builder', function() {
   it ('should construct a nodejs package', function(done) {
     var opts = _.merge({
       packageInfo: testPackageInfo,
+      nodejsUsePbjs: true,
       top: path.join(top, 'nodejs')
     }, templateDirs.nodejs);
     var copies = [
@@ -339,6 +350,38 @@ describe('the nodejs package builder', function() {
       'nodejs/README.md'
     ];
     var compareWithFixture = genFixtureCompareFunc(top);
+    var checkExpanded = function checkExpanded(next) {
+      var expandTasks = _.map(expanded, compareWithFixture);
+      async.parallel(expandTasks, next);
+    };
+    async.series([
+      packager.nodejs.bind(null, opts),
+      checkCopies,
+      checkExpanded
+    ], done);
+  });
+
+  it ('should construct a proto-based nodejs package', function(done) {
+    var opts = _.merge({
+      packageInfo: testPackageInfo,
+      nodejsUsePbjs: false,
+      top: path.join(top, 'nodejs')
+    }, templateDirs.nodejs);
+    opts.packageInfo.nodejsUseProtos = true;
+    var copies = [
+      'nodejs/index.js',
+      'nodejs/PUBLISHING.md'
+    ];
+    var checkCopies = function checkCopies(next) {
+      var checkACopy = genCopyCompareFunc(top);
+      var copyTasks = _.map(copies, checkACopy);
+      async.parallel(copyTasks, next);
+    };
+    var expanded = [
+      'nodejs/package.json',
+      'nodejs/README.md'
+    ];
+    var compareWithFixture = genFixtureCompareFunc(top, ['proto-based']);
     var checkExpanded = function checkExpanded(next) {
       var expandTasks = _.map(expanded, compareWithFixture);
       async.parallel(expandTasks, next);


### PR DESCRIPTION
Currently nodejs grpc client uses pbjs to convert the .proto files
into JSON format. However the generated JSON format / loaded data
does not work with grpc (see #35).

The new client instead copies .proto files to the output directory,
and uses protobufjs.loadProtoFile. gRPC actually works well with
this approach.

Fixes #35