### PR TITLE
Add google/protobuf files to the dependency.

### DIFF
--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -395,7 +395,7 @@ ApiRepo.prototype.buildCommonProtoPkgs =
  * called with the list of file name within the includePath when
  * the task has finished.
  */
-function collectProtoDeps(protoFile, includePath, done) {
+function collectProtoDeps(includePath, protoFile, done) {
   var deps = tmp.fileSync();
   var desc = tmp.fileSync();
   var args = ['--dependency_out=' + deps.name, '-o', desc.name];
@@ -422,6 +422,49 @@ function collectProtoDeps(protoFile, includePath, done) {
     });
   });
 }
+
+/**
+ * Create the mapping of the .proto file source to the destination.
+ *
+ * This is a sub task of 'ProtoBased' nodeJS module in _buildProtos, but
+ * extracted as a method for the testing.
+ *
+ * @param {string} outDir - the top of the output directory.
+ * @param {[][]string} fileList - the list of the lists of the .proto files
+ *   to be copied.
+ * @returns {Object} - an object whose keys are the source files (i.e. items
+ *   in fileList) and values are the path of the files relative to
+ *   the output destinations.
+ */
+ApiRepo.prototype._buildProtoFilesMapping = function _buildProtoFilesMapping(
+    fileLists, includePath) {
+  var filesMap = {};
+  // Each item in fileLists is the list of .proto files calculated by
+  // collectProtoDeps.
+  fileLists.forEach(function(fileList) {
+    fileList.forEach(function(filePath) {
+      if (filePath in filesMap) {
+        return;
+      }
+      for (var i = 0; i < includePath.length; ++i) {
+        if (filePath.indexOf(includePath[i]) === 0) {
+          var relativePath = filePath.slice(includePath[i].length + 1);
+          filesMap[filePath] = path.join(relativePath);
+          return;
+        }
+      }
+      // Files under google/protobuf are not found in the includePath, but
+      // in the installation of protobuf itself.
+      var matched = filePath.match(/\bgoogle\/protobuf\/[^\/]*.proto$/);
+      if (matched) {
+        filesMap[filePath] = path.join(matched[0]);
+      } else {
+        console.warn('Unexpected dependency file: ' + filePath);
+      }
+    });
+  });
+  return filesMap;
+};
 
 /**
  * _buildProtos builds the protos for named api and version in the target languages.
@@ -474,53 +517,21 @@ ApiRepo.prototype._buildProtos =
          */
         var makeProtoBasedNodeModule =
             function makeProtoBasedNodeModule(fullPathProtos, includePath) {
-          // filesMap keeps the mapping for proto files from the source file
-          // locaiton to the destination.
-          var filesMap = {};
           var outDir = path.join(langTopDir, 'proto');
-
-          /** Add an entry for filePath to filesMap. */
-          function addToFilesMap(filePath) {
-            if (filePath in filesMap) {
+          async.map(fullPathProtos, collectProtoDeps.bind(null, includePath),
+                    function (err, fileLists) {
+            if (err) {
+              findOutputs(err);
               return;
             }
-            for (var i = 0; i < includePath.length; ++i) {
-              if (filePath.indexOf(includePath[i]) === 0) {
-                var relativePath = filePath.slice(includePath[i].length + 1);
-                filesMap[filePath] = path.join(outDir, relativePath);
-                return;
-              }
-            }
-            // Files under google/protobuf are not found in the includePath, but
-            // in the installation of protobuf itself.
-            var matched = filePath.match(/\bgoogle\/protobuf\/[^\/]*.proto$/);
-            if (matched) {
-              filesMap[filePath] = path.join(outDir, matched[0]);
-            } else {
-              console.warn('Unexpected dependency file: ' + filePath);
-            }
-          }
-
-          var tasks = _.map(fullPathProtos, function(proto) {
-            return function collectProtoTask(next) {
-              collectProtoDeps(proto, includePath, function(err, deps) {
-                if (err) {
-                  next(err);
-                  return;
-                }
-                // Building filesMap contents for the dependencies.
-                deps.forEach(addToFilesMap);
-                next();
-              });
-            };
-          });
-          async.waterfall(tasks, function(err) {
+            var filesMap = this._buildProtoFilesMapping(fileLists, includePath);
             async.forEachOf(filesMap, function(dst, src, next) {
-              fs.mkdirsSync(path.dirname(dst));
-              fs.copy(src, dst, next);
+              var finalDst = path.join(outDir, dst);
+              fs.mkdirsSync(path.dirname(finalDst));
+              fs.copy(src, finalDst, next);
             }, findOutputs);
-          });
-        };
+          }.bind(this));
+        }.bind(this);
         /**
          * makeNodeModule writes a commonJS module containing all the protos
          * used by service.

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -491,6 +491,14 @@ ApiRepo.prototype._buildProtos =
                 return;
               }
             }
+            // Files under google/protobuf are not found in the includePath, but
+            // in the installation of protobuf itself.
+            var matched = filePath.match(/\bgoogle\/protobuf\/[^\/]*.proto$/);
+            if (matched) {
+              filesMap[filePath] = path.join(outDir, matched[0]);
+            } else {
+              console.warn('Unexpected dependency file: ' + filePath);
+            }
           }
 
           var tasks = _.map(fullPathProtos, function(proto) {

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -431,7 +431,8 @@ function collectProtoDeps(includePath, protoFile, done) {
  *
  * @param {string} outDir - the top of the output directory.
  * @param {[][]string} fileList - the list of the lists of the .proto files
- *   to be copied.
+ *   to be copied. Each item is the list of .proto files calculated by
+ *   collectProtoDeps.
  * @returns {Object} - an object whose keys are the source files (i.e. items
  *   in fileList) and values are the path of the files relative to
  *   the output destinations.
@@ -439,8 +440,6 @@ function collectProtoDeps(includePath, protoFile, done) {
 ApiRepo.prototype._buildProtoFilesMapping = function _buildProtoFilesMapping(
     fileLists, includePath) {
   var filesMap = {};
-  // Each item in fileLists is the list of .proto files calculated by
-  // collectProtoDeps.
   fileLists.forEach(function(fileList) {
     fileList.forEach(function(filePath) {
       if (filePath in filesMap) {
@@ -453,8 +452,11 @@ ApiRepo.prototype._buildProtoFilesMapping = function _buildProtoFilesMapping(
           return;
         }
       }
-      // Files under google/protobuf are not found in the includePath, but
-      // in the installation of protobuf itself.
+      // Files under google/protobuf might not be found in the includePath but
+      // in the default location (such as /usr/include), however the actual
+      // location is not known without running protoc actually. Here finds the
+      // pattern of google/protobuf/*.proto and crete the mapping from the
+      // file path.
       var matched = filePath.match(/\bgoogle\/protobuf\/[^\/]*.proto$/);
       if (matched) {
         filesMap[filePath] = path.join(matched[0]);

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -101,9 +101,11 @@ describe('ApiRepo', function() {
   describe('on the test fixture repo with no plugins', function() {
     var fakes, repo;
     describe('configured for nodejs', function(){
+      // TODO: add a test case for nodejsUsePbjs: false.
       beforeEach(function() {
         repo = new ApiRepo({
           isGoogleApi: true,
+          nodejsUsePbjs: true,
           includePath: [path.join(__dirname, 'fixtures', 'include')],
           languages: ['nodejs'],
           templateRoot: path.join(__dirname, '..', 'templates')

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -578,4 +578,42 @@ describe('ApiRepo', function() {
       repo._checkDeps({env: {'PATH': fakes.path}}, errsOn(done));
     });
   });
+  describe('method `_buildProtoFilesMapping`', function() {
+    var repo;
+    var includePath = ['/tmp/foo', '/tmp/bar'];
+    before(function() {
+      // nodejs is not required, but used by it.
+      repo = new ApiRepo({languages: ['nodejs']});
+    });
+    it('unifies same files into one entry', function() {
+      var filesMap = repo._buildProtoFilesMapping([
+        ['/tmp/foo/foo.proto', '/tmp/foo/foo2.proto', '/tmp/foo/base.proto'],
+        ['/tmp/foo/base.proto', '/tmp/bar/package/bar.proto']
+      ], includePath);
+      expect(filesMap).to.deep.equal({
+        '/tmp/foo/foo.proto': 'foo.proto',
+        '/tmp/foo/foo2.proto': 'foo2.proto',
+        '/tmp/foo/base.proto': 'base.proto',
+        '/tmp/bar/package/bar.proto': 'package/bar.proto'
+      });
+    });
+
+    it('recognizes the default proto', function() {
+      var filesMap = repo._buildProtoFilesMapping([
+        ['/tmp/foo/foo.proto', '/tmp/foo/foo2.proto',
+         '/usr/local/include/google/protobuf/descriptor.proto'],
+        ['/usr/local/include/google/protobuf/empty.proto',
+         '/tmp/bar/package/bar.proto']
+      ], includePath);
+      expect(filesMap).to.deep.equal({
+        '/tmp/foo/foo.proto': 'foo.proto',
+        '/tmp/foo/foo2.proto': 'foo2.proto',
+        '/tmp/bar/package/bar.proto': 'package/bar.proto',
+        '/usr/local/include/google/protobuf/descriptor.proto':
+          'google/protobuf/descriptor.proto',
+        '/usr/local/include/google/protobuf/empty.proto':
+          'google/protobuf/empty.proto'
+      });
+    });
+  });
 });


### PR DESCRIPTION
These files are not bundled in ProtoBuf.js, so they should be
copied as well, but this code gently ignore these files because
they are not in the includePath.

Added the code to copy them, and prints warning message in case
some unexpected files are included.