### PR TITLE
Fix a failure of packman for --build_common_protos flag.

### DIFF
--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -853,7 +853,10 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         args.push('--' + language + '_out=skip-imported=true:' + outDir);
         pluginOption = '--plugin=';
       } else {
-        args.push('--' + language + '_out=' + outDir, '--grpc_out=' + outDir);
+        args.push('--' + language + '_out=' + outDir);
+        if (!opts.buildCommonProtos) {
+          args.push('--grpc_out=' + outDir);
+        }
       }
       if (!opts.buildCommonProtos) {
         var pluginBin = that.depBins[that._getPluginName(language, that.overridePlugins)];


### PR DESCRIPTION
The grpc plugin command-line is omitted when this flag is specified,
thus --grpc_out should also be omitted.