### PR TITLE
Update dependency version

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -25,11 +25,11 @@ semver:
   go: '0.6.0'
   objc: '0.6.0'
   java: '0.6.0'
-  nodejs: '0.6.0'
+  nodejs: '0.7.1'
   # TODO: Python must go to 1.0.20 or 1.1.0 when we GA, due to mistakenly
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
   python: '0.7.11'
-  ruby: '0.6.6'
+  ruby: '0.6.7'
   php: '0.6.0'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -38,7 +38,7 @@ grpc:
   ruby:
     version: '0.14.1'
   nodejs:
-    version: '0.14.1'
+    version: '0.15.0'
   php:
     version: '0.14.1'
 
@@ -46,9 +46,9 @@ gax:
   python:
     version: '0.12.2'
   ruby:
-    version: '0.3.0'
+    version: '0.4.0'
   nodejs:
-    version: '0.3.2'
+    version: '0.5.1'
 
 protobuf:
   python:
@@ -69,7 +69,4 @@ googleapis_common_protos:
 nodeModules:
   arguejs:
     version: '0.2.3'
-  fsPromise:
-    version: '0.5.0'
-  through2:
-    version: '2.0.1'
+

--- a/templates/gax/nodejs/package.json.mustache
+++ b/templates/gax/nodejs/package.json.mustache
@@ -7,11 +7,8 @@
   "license": "{{api.license}}",
   "dependencies": {
     "arguejs": "^{{dependencies.nodeModules.arguejs.version}}",
-    "fs-promise": "^{{dependencies.nodeModules.fsPromise.version}}",
-    "through2": "^{{dependencies.nodeModules.through2.version}}",
     "google-gax": "^{{dependencies.gax.nodejs.version}}",
     "grpc": "^{{{dependencies.grpc.nodejs.version}}}",
-    "google-auth-library": "^{{{dependencies.auth.nodejs.version}}}",
     "{{api.dependsOn}}-{{api.version}}": "^{{api.semantic_version}}"
   },
   "main": "index.js"


### PR DESCRIPTION
- Update google-gax versions
- Update grpc-nodejs to 0.15.0
- Remove unnecessary dependencies from gapic-generated nodejs packages.