### PR TITLE
Update Ruby gRPC dependency to 0.15.0

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -31,5 +31,5 @@ semver:
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
   python: '0.7.11'
-  ruby: '0.6.7'
+  ruby: '0.6.8'
   php: '0.6.0'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -36,7 +36,7 @@ grpc:
   python:
     version: '0.15.0'
   ruby:
-    version: '0.14.1'
+    version: '0.15.0'
   nodejs:
     version: '0.15.0'
   php:
@@ -46,7 +46,7 @@ gax:
   python:
     version: '0.12.2'
   ruby:
-    version: '0.4.0'
+    version: '0.4.1'
   nodejs:
     version: '0.5.1'
 


### PR DESCRIPTION
This also changes the dependency on gax, which is updated to
0.4.1 by https://github.com/googleapis/gax-ruby/pull/34