### PR TITLE
Include LICENSE in Python gRPC packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-packman",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "bin": {
     "gen-api-package": "bin/gen-api-package"
   },

--- a/templates/python/MANIFEST.in
+++ b/templates/python/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst
+include README.rst LICENSE


### PR DESCRIPTION
Adds the LICENSE file into the MANIFEST.in used for gRPC Python
packages.