### PR TITLE
Fix protoc version in java build template

### DIFF
--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -28,9 +28,9 @@ repositories {
 }
 
 dependencies {
-  compile "com.google.protobuf:protobuf-java:3.0.0-beta-3"
+  compile "com.google.protobuf:protobuf-java:3.0.0-beta-4"
   compile "io.gapi:googleapis-common-protos:0.0.0-SNAPSHOT"
-  compile "io.grpc:grpc-all:0.14.1"
+  compile "io.grpc:grpc-all:0.15.0"
 }
 
 protobuf {
@@ -38,11 +38,11 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = "com.google.protobuf:protoc:3.0.0-beta-3"
+    artifact = "com.google.protobuf:protoc:3.0.0-beta-4"
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:0.14.1'
+      artifact = 'io.grpc:protoc-gen-grpc-java:0.15.0'
     }
   }
   generateProtoTasks {


### PR DESCRIPTION
Packman was using incompatible versions of protobuf which causes compile erros in the generated grpc package.