### PR TITLE
replace to replace all occurrences.

### DIFF
--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -220,9 +220,10 @@ ApiRepo.prototype.buildPackages =
               });
               opts.packageInfo.nodejsUseProtos = true;
             }
-            var cleanName = name.replace('/', '-');
+            var cleanName = name.replace(new RegExp('/', 'g'), '-');
             opts.packageInfo.api.simplename = cleanName;
-            opts.packageInfo.api.path = cleanName.replace('-', '/');
+            opts.packageInfo.api.path =
+                cleanName.replace(new RegExp('-', 'g'), '/');
             opts.packageInfo.api.name = that.pkgPrefix + cleanName;
             opts.packageInfo.api.version = version;
             var semver = opts.packageInfo.api.semver[l];


### PR DESCRIPTION
In JS, replace() with a string will replace only the first
occurrence, thus this is going to fail if multiple words are
involved (like 'google-cloud-language').