### PR TITLE
Fix group name of generated grpc java package.

### DIFF
--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -10,9 +10,9 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'com.google.protobuf'
 
-description = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
-group = "io.gapi"
-version = "{{{api.semantic_version}}}"
+description = 'GRPC library for service {{api.name}}-{{api.version}}'
+group = "com.google.api"
+version = "{{api.semantic_version}}"
 // TODO: use a flag to determine whether to produce a release or a snapshot
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -94,7 +94,7 @@ if (rootProject.hasProperty('mavenRepoUrl')) {
     }
     repository(url: mavenRepoUrl, configureAuth)
     pom.project {
-      name "io.gapi:grpc-google-pubsub-v1"
+      name "com.google.api:grpc-{{api.name}}-{{api.version}}"
       description project.description
       url 'https://github.com/googleapis/googleapis'
       scm {

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -10,9 +10,9 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'com.google.protobuf'
 
-description = 'GRPC library for service {{api.name}}-{{api.version}}'
+description = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
 group = "com.google.api"
-version = "{{api.semantic_version}}"
+version = "{{{api.semantic_version}}}"
 // TODO: use a flag to determine whether to produce a release or a snapshot
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -94,7 +94,7 @@ if (rootProject.hasProperty('mavenRepoUrl')) {
     }
     repository(url: mavenRepoUrl, configureAuth)
     pom.project {
-      name "com.google.api:grpc-{{api.name}}-{{api.version}}"
+      name "com.google.api:grpc-{{{api.name}}}-{{{api.version}}}"
       description project.description
       url 'https://github.com/googleapis/googleapis'
       scm {

--- a/templates/java/build.gradle.mustache
+++ b/templates/java/build.gradle.mustache
@@ -2,9 +2,9 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-description = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
-group = "io.gapi"
-version = "{{{api.semantic_version}}}-SNAPSHOT"
+description = 'GRPC library for service {{api.name}}-{{api.version}}'
+group = "com.google.api"
+version = "{{api.semantic_version}}-SNAPSHOT"
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
@@ -60,7 +60,7 @@ uploadArchives.repositories.mavenDeployer {
   uploadArchives.repositories.mavenDeployer,
 ]*.pom { pom ->
   pom.project {
-    name "io.gapi:{{{api.name}}}-{{{api.version}}}"
+    name "com.google.api:{{api.name}}-{{api.version}}"
     description project.description
     url '{{{api.homepage}}}'
 

--- a/templates/java/build.gradle.mustache
+++ b/templates/java/build.gradle.mustache
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-description = 'GRPC library for service {{api.name}}-{{api.version}}'
+description = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
 group = "com.google.api"
 version = "{{api.semantic_version}}-SNAPSHOT"
 sourceCompatibility = 1.6
@@ -60,7 +60,7 @@ uploadArchives.repositories.mavenDeployer {
   uploadArchives.repositories.mavenDeployer,
 ]*.pom { pom ->
   pom.project {
-    name "com.google.api:{{api.name}}-{{api.version}}"
+    name "com.google.api:{{{api.name}}}-{{{api.version}}}"
     description project.description
     url '{{{api.homepage}}}'
 

--- a/test/fixtures/java/build.gradle
+++ b/test/fixtures/java/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 description = 'GRPC library for service packager-unittest-v2'
-group = "io.gapi"
+group = "com.google.api"
 version = "1.0.0-SNAPSHOT"
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -60,7 +60,7 @@ uploadArchives.repositories.mavenDeployer {
   uploadArchives.repositories.mavenDeployer,
 ]*.pom { pom ->
   pom.project {
-    name "io.gapi:packager-unittest-v2"
+    name "com.google.api:packager-unittest-v2"
     description project.description
     url 'https://github.com/google/googleapis'
 


### PR DESCRIPTION
This PR should fix: https://github.com/googleapis/packman/issues/68, https://github.com/googleapis/packman/issues/70