### PR TITLE
Kill the isGoogleApi flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ defines protobuf services in a layout similar to that of
 
 
 ```
-gen-api-package --api_name=my_new_service/v1 -l python -r my_protobuf_dir
+gen-api-package --api_name=my_new_service/v1 -l python -r my_protobuf_dir/my_new_service/v1
 ```
 
 Generate the python package for Google's logging/v2 API, where logging/v2 is
@@ -59,7 +59,7 @@ usage: gen-api-package [-h] [-v] [-x] [-i INCLUDEPATH] [-o OUTDIR]
                        [--dependencies_file DEPSFILE]
                        [--common_protos_file COMMONPBFILE]
                        [--package_prefix PKGPREFIX]
-                       [--template_root TEMPLATEROOT] [-g]
+                       [--template_root TEMPLATEROOT]
                        [--override_plugins OVERRIDEPLUGINS]
 
 
@@ -119,9 +119,6 @@ Optional arguments:
                         generation. The template root must contain the same
                         files for any specified languages as in the builtin
                         template root.
-  -g, --is_google_api   When set indicates that the API is an official google
-                        API. It means that there is a top-level "google"
-                        directory in the target protocol buffer repository.
   --override_plugins OVERRIDEPLUGINS
                         Specifies the override protoc plugins to be used. E.g
                         by default the plugin for python is named

--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -187,17 +187,6 @@ var parseArgs = function parseArgs() {
     }
   );
   cli.addArgument(
-    [ '-g', '--is_google_api' ],
-    {
-      defaultValue: false,
-      action: 'storeTrue',
-      help: 'When set indicates that the API is an official google API.\n'
-            + ' It means that there is a top-level "google" directory in'
-            + ' the target protocol buffer repository.',
-      dest: 'isGoogleApi'
-    }
-  );
-  cli.addArgument(
     [ '--experimental_alt_java' ],
     {
       defaultValue: false,
@@ -255,11 +244,7 @@ var parsePlugins = function parsePlugins(pluginSpecs) {
  */
 var main = function main() {
   var opts = parseArgs();
-  if (opts.isGoogleApi && !opts.pkgPrefix) {
-    opts.pkgPrefix = 'grpc-google-';
-  }
   if (opts.buildCommonProtos) {
-    opts.isGoogleApi = true;
     opts.pkgPrefix = 'googleapis-common-protos';
     opts.apiName = 'googleapis-common-protos';
     opts.apiVersion = '';

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -95,7 +95,6 @@ ApiRepo.prototype =
  * - the configured api repository is valid and available.
  *
  * repo = new ApiRepo({
- *   isGoogleApi: true,
  *   languages: ['python', 'ruby']
  * });
  *
@@ -181,7 +180,7 @@ var rootTemplateDir = function rootTemplateDir(templateInfo, root) {
  * It is to be called once the repo is 'ready' after setUp is called.
  *
  * repo = new ApiRepo({
- *   isGoogleApi: true,
+ *   repoDirs: ['path/to/name/version']
  *   languages: ['python', 'ruby']
  * });
  * repo.on('ready', function() {
@@ -247,7 +246,7 @@ ApiRepo.prototype.buildPackages =
  * It is to be called once the repo is 'ready' after setUp is called.
  *
  * repo = new ApiRepo({
- *   isGoogleApi: true,
+ *   repoDirs: ['path/to/name/version']
  *   languages: ['python', 'ruby']
  * });
  * repo.on('ready', function() {
@@ -357,6 +356,7 @@ ApiRepo.prototype._wrapDone = function _wrapDone(optDone) {
  * It is to be called once the repo is 'ready' after setUp is called.
  *
  * repo = new ApiRepo({
+ *   repoDirs: ['path/to/name/version']
  *   languages: ['python', 'ruby']
  * });
  * repo.on('ready', function() {

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -95,6 +95,7 @@ ApiRepo.prototype =
  * - the configured api repository is valid and available.
  *
  * repo = new ApiRepo({
+ *   repoDirs: ['path/to/name/version']
  *   languages: ['python', 'ruby']
  * });
  *

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -77,7 +77,7 @@ function ApiRepo(opts) {
   this.pkgPrefix = opts.pkgPrefix;
   this.overridePlugins = opts.overridePlugins;
   this.zipUrl = opts.zipUrl;
-  this.isGoogleApi = !!opts.isGoogleApi;
+  this.isGoogleApi = !!opts.buildCommonProtos;
   if (_.isEmpty(this.repoDirs) && !this.zipUrl) {
     this.zipUrl = GOOGLE_APIS_REPO_ZIP; // default to download googleapis
     this.isGoogleApi = true;

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -103,7 +103,6 @@ describe('ApiRepo', function() {
       // TODO: add a test case for nodejsUsePbjs: false.
       beforeEach(function() {
         repo = new ApiRepo({
-          isGoogleApi: true,
           nodejsUsePbjs: true,
           includePath: [path.join(__dirname, 'fixtures', 'include')],
           languages: ['nodejs'],
@@ -139,7 +138,6 @@ describe('ApiRepo', function() {
         fakes = addFakeBinsToPath.apply(null, testBins);
         repo = new ApiRepo({
           env: {PATH: fakes.path},
-          isGoogleApi: true,
           languages: ['python'],
           templateRoot: path.join(__dirname, '..', 'templates')
         });
@@ -183,7 +181,6 @@ describe('ApiRepo', function() {
         fakes = addFakeBinsToPath.apply(null, testBins);
         repo = new ApiRepo({
           env: {PATH: fakes.path},
-          isGoogleApi: true,
           languages: ['ruby'],
           templateRoot: path.join(__dirname, '..', 'templates')
         });
@@ -218,7 +215,6 @@ describe('ApiRepo', function() {
         beforeEach(function() {
           repo = new ApiRepo({
             env: {PATH: fakes.path},
-            isGoogleApi: true,
             languages: ['ruby', 'python'],
             templateRoot: path.join(__dirname, '..', 'templates')
           });
@@ -238,7 +234,6 @@ describe('ApiRepo', function() {
         beforeEach(function() {
           repo = new ApiRepo({
             env: {PATH: fakes.path},
-            isGoogleApi: true,
             languages: ['ruby', 'python'],
             templateRoot: path.join(__dirname, '..', 'templates')
           });
@@ -279,7 +274,6 @@ describe('ApiRepo', function() {
     beforeEach(function(done) {
       fakes = addFakeProtocToPath();
       repo = new ApiRepo({
-        isGoogleApi: true,
         env: {PATH: fakes.path}
       });
       getsGoodZipFrom(repo.zipUrl);
@@ -334,7 +328,6 @@ describe('ApiRepo', function() {
     });
     it('should fail if protoc fails during build', function(done) {
       var badProtocRepo = new ApiRepo({
-        isGoogleApi: true,
         env: {PATH: fakes.badPath}
       });
       getsGoodZipFrom(badProtocRepo.zipUrl);
@@ -447,9 +440,7 @@ describe('ApiRepo', function() {
     describe('using `zipUrl`', function() {
       var repo;
       beforeEach(function(done) {
-        repo = new ApiRepo({
-          isGoogleApi: true
-        });
+        repo = new ApiRepo();
         getsGoodZipFrom(repo.zipUrl);
         repo._checkRepo(done); // partially initialize the repo
       });
@@ -527,7 +518,7 @@ describe('ApiRepo', function() {
     it('should pass if repoDirs and reqd subdir are present', function(done) {
       var repo = new ApiRepo({
         repoDirs: [withSubdir],
-        isGoogleApi: true
+        buildCommonProtos: true
       });
       repo._checkRepo(passesOn(done));
     });
@@ -546,7 +537,7 @@ describe('ApiRepo', function() {
     it('should fail if repoDirs is missing reqd subdir', function(done) {
       var repo = new ApiRepo({
         repoDirs: [withoutSubdir],
-        isGoogleApi: true
+        buildCommonProtos: true
       });
       repo._checkRepo(errsOn(done));
     });
@@ -577,7 +568,7 @@ describe('ApiRepo', function() {
       });
       it('should verify the default repo subdir', function(done) {
         var repo = new ApiRepo({
-          isGoogleApi: true
+          buildCommonProtos: true
         });
         expect(repo.zipUrl).to.not.be.null();
         expect(repo.repoDir).to.be.undefined();


### PR DESCRIPTION
We are not using this flag anywhere, and it's better not to
have special logic for Google APIs. In the implementation, a
variable of the same name remains because it is necessary to support
the GitHub zip archive use case.