### PR TITLE
Disable HTML escaping across all templates

### DIFF
--- a/templates/commonpb/java/build-alt.gradle.mustache
+++ b/templates/commonpb/java/build-alt.gradle.mustache
@@ -13,7 +13,7 @@ apply plugin: 'com.google.protobuf'
 description = 'Common protobufs used in Google APIs'
 group = "io.gapi"
 version = "0.0.0-SNAPSHOT"
-// version = "{{api.semantic_version}}-SNAPSHOT"
+// version = "{{{api.semantic_version}}}-SNAPSHOT"
 // TODO: switch to this once all common protos are actually public
 // TODO: use a flag to determine whether to produce a release or a snapshot
 
@@ -86,7 +86,7 @@ uploadArchives.repositories.mavenDeployer {
   uploadArchives.repositories.mavenDeployer,
 ]*.pom { pom ->
   pom.project {
-    name "io.gapi:{{api.name}}"
+    name "io.gapi:{{{api.name}}}"
     description project.description
     url '{{{api.homepage}}}'
 
@@ -98,16 +98,16 @@ uploadArchives.repositories.mavenDeployer {
 
     licenses {
       license {
-        name '{{api.license}}'
+        name '{{{api.license}}}'
         url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
      }
     }
 
     developers {
       developer {
-        id "{{api.email}}"
-        name "{{api.author}}"
-        email "{{api.email}}"
+        id "{{{api.email}}}"
+        name "{{{api.author}}}"
+        email "{{{api.email}}}"
         url "{{{api.homepage}}}"
         // https://issues.gradle.org/browse/GRADLE-2719
         organization = "Google, Inc."

--- a/templates/commonpb/java/build.gradle.mustache
+++ b/templates/commonpb/java/build.gradle.mustache
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 description = 'Common protobufs used in Google APIs'
 group = "io.gapi"
 version = "0.0.0-SNAPSHOT"
-// version = "{{api.semantic_version}}-SNAPSHOT"
+// version = "{{{api.semantic_version}}}-SNAPSHOT"
 // TODO: switch to this once all common protos are actually public
 // TODO: use a flag to determine whether to produce a release or a snapshot
 
@@ -69,7 +69,7 @@ uploadArchives.repositories.mavenDeployer {
   uploadArchives.repositories.mavenDeployer,
 ]*.pom { pom ->
   pom.project {
-    name "io.gapi:{{api.name}}"
+    name "io.gapi:{{{api.name}}}"
     description project.description
     url '{{{api.homepage}}}'
 
@@ -81,16 +81,16 @@ uploadArchives.repositories.mavenDeployer {
 
     licenses {
       license {
-        name '{{api.license}}'
+        name '{{{api.license}}}'
         url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
      }
     }
 
     developers {
       developer {
-        id "{{api.email}}"
-        name "{{api.author}}"
-        email "{{api.email}}"
+        id "{{{api.email}}}"
+        name "{{{api.author}}}"
+        email "{{{api.email}}}"
         url "{{{api.homepage}}}"
         // https://issues.gradle.org/browse/GRADLE-2719
         organization = "Google, Inc."

--- a/templates/commonpb/java/settings.gradle.mustache
+++ b/templates/commonpb/java/settings.gradle.mustache
@@ -1,1 +1,1 @@
-rootProject.name = '{{api.name}}'
+rootProject.name = '{{{api.name}}}'

--- a/templates/commonpb/python/setup.py.mustache
+++ b/templates/commonpb/python/setup.py.mustache
@@ -10,15 +10,15 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
-  'protobuf>={{dependencies.protobuf.python.version}}'
+  'protobuf>={{{dependencies.protobuf.python.version}}}'
 ]
 
 setuptools.setup(
-  name='{{api.name}}',
-  version='{{api.semantic_version}}',
+  name='{{{api.name}}}',
+  version='{{{api.semantic_version}}}',
 
-  author='{{api.author}}',
-  author_email='{{api.email}}',
+  author='{{{api.author}}}',
+  author_email='{{{api.email}}}',
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -30,8 +30,8 @@ setuptools.setup(
   description='Common protobufs used in Google APIs',
   long_description=open('README.rst').read(),
   install_requires=install_requires,
-  license='{{api.license}}',
+  license='{{{api.license}}}',
   packages=find_packages(),
-  namespace_packages=[{{#api.nsPackages}}'{{.}}', {{/api.nsPackages}}],
+  namespace_packages=[{{#api.nsPackages}}'{{{.}}}', {{/api.nsPackages}}],
   url='{{{api.homepage}}}'
 )

--- a/templates/commonpb/ruby/gemspec.mustache
+++ b/templates/commonpb/ruby/gemspec.mustache
@@ -2,21 +2,21 @@
 # encoding: utf-8
 
 Gem::Specification.new do |s|
-  s.name          = '{{api.name}}'
-  s.version       = '{{api.semantic_version}}'
+  s.name          = '{{{api.name}}}'
+  s.version       = '{{{api.semantic_version}}}'
 
-  s.authors       = ['{{api.author}}']
-  s.description   = '{{api.description}}'
-  s.email         = '{{api.email}}'
+  s.authors       = ['{{{api.author}}}']
+  s.description   = '{{{api.description}}}'
+  s.email         = '{{{api.email}}}'
   s.files         = Dir.glob(File.join('lib', '**', '*.rb'))
   s.homepage      = '{{{api.homepage}}}'
-  s.license       = '{{api.license}}'
+  s.license       = '{{{api.license}}}'
   s.platform      = Gem::Platform::RUBY
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.0.0'
   s.summary       = 'Common protobufs used in Google APIs'
 
-  s.add_dependency 'google-protobuf', '~> {{dependencies.protobuf.ruby.version}}'
+  s.add_dependency 'google-protobuf', '~> {{{dependencies.protobuf.ruby.version}}}'
 
   s.add_development_dependency 'bundler', '~> 1.9'
   s.add_development_dependency 'rake', '~> 10.4'

--- a/templates/gax/nodejs/README.md.mustache
+++ b/templates/gax/nodejs/README.md.mustache
@@ -1,18 +1,18 @@
-GAX library for the Google {{api.titlename}} API
+GAX library for the Google {{{api.titlename}}} API
 =================================================
 
-{{api.name}}-{{api.version}} uses [Google API extensions][google-gax] to provide an
-easy-to-use client library for the [Google {{api.titlename}} API][] ({{api.version}}) defined in the [googleapis][] git repository
+{{{api.name}}}-{{{api.version}}} uses [Google API extensions][google-gax] to provide an
+easy-to-use client library for the [Google {{{api.titlename}}} API][] ({{{api.version}}}) defined in the [googleapis][] git repository
 
 
-[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/{{api.path}}/{{api.version}}
+[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/{{{api.path}}}/{{{api.version}}}
 [google-gax]: https://github.com/googleapis/gax-nodejs
-[Google {{api.titlename}} API]: https://developers.google.com/apis-explorer/#p/{{api.shortname}}/{{api.version}}/
+[Google {{{api.titlename}}} API]: https://developers.google.com/apis-explorer/#p/{{{api.shortname}}}/{{{api.version}}}/
 
 Getting started
 ---------------
 
-{{api.name}}-{{api.version}} will allow you to connect to the [Google {{api.titlename}} API][] and access all its methods.
+{{{api.name}}}-{{{api.version}}} will allow you to connect to the [Google {{{api.titlename}}} API][] and access all its methods.
 
 In order to do so, you need to set up authentication as well as install the library locally.
 
@@ -40,6 +40,6 @@ Installation
 
 Install this library using npm:
 
-    $ npm install {{api.name}}-{{api.version}}
+    $ npm install {{{api.name}}}-{{{api.version}}}
 
 At this point you are all set to continue.

--- a/templates/gax/nodejs/index.js.mustache
+++ b/templates/gax/nodejs/index.js.mustache
@@ -15,7 +15,7 @@
  */
 
 {{#apiFiles}}
-var apiClient = require('./lib/{{.}}');
+var apiClient = require('./lib/{{{.}}}');
 for (var key in apiClient) {
   exports[key] = apiClient[key];
 }

--- a/templates/gax/nodejs/package.json.mustache
+++ b/templates/gax/nodejs/package.json.mustache
@@ -4,12 +4,12 @@
   "version": "{{{api.semantic_version}}}",
   "author": "Google Inc.",
   "description": "GRPC library for service {{{api.name}}}-{{{api.version}}}",
-  "license": "{{api.license}}",
+  "license": "{{{api.license}}}",
   "dependencies": {
-    "arguejs": "^{{dependencies.nodeModules.arguejs.version}}",
-    "google-gax": "^{{dependencies.gax.nodejs.version}}",
+    "arguejs": "^{{{dependencies.nodeModules.arguejs.version}}}",
+    "google-gax": "^{{{dependencies.gax.nodejs.version}}}",
     "grpc": "^{{{dependencies.grpc.nodejs.version}}}",
-    "{{api.dependsOn}}-{{api.version}}": "^{{api.semantic_version}}"
+    "{{{api.dependsOn}}}-{{{api.version}}}": "^{{{api.semantic_version}}}"
   },
   "main": "index.js"
 }

--- a/templates/gax/python/README.rst.mustache
+++ b/templates/gax/python/README.rst.mustache
@@ -1,19 +1,19 @@
-GAX library for the Google {{api.titlename}} API
+GAX library for the Google {{{api.titlename}}} API
 ================================================================================
 
-{{api.name}}-{{api.version}} uses google-gax_ (Google API extensions) to provide an
-easy-to-use client library for the `Google {{api.titlename}} API`_ ({{api.version}}) defined in the googleapis_ git repository
+{{{api.name}}}-{{{api.version}}} uses google-gax_ (Google API extensions) to provide an
+easy-to-use client library for the `Google {{{api.titlename}}} API`_ ({{{api.version}}}) defined in the googleapis_ git repository
 
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{{{api.path}}}/{{{api.version}}}
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`Google {{api.titlename}} API`: https://developers.google.com/apis-explorer/?hl=en_US#p/{{{api.shortname}}}/{{{api.version}}}/
+.. _`Google {{{api.titlename}}} API`: https://developers.google.com/apis-explorer/?hl=en_US#p/{{{api.shortname}}}/{{{api.version}}}/
 
 Getting started
 ---------------
 
-{{api.name}}-{{api.version}} will allow you to connect to the Google
-{{api.titlename}} API and access all its methods. In order to do this, you need
+{{{api.name}}}-{{{api.version}}} will allow you to connect to the Google
+{{{api.titlename}}} API and access all its methods. In order to do this, you need
 to set up authentication as well as install the library locally.
 
 
@@ -61,7 +61,7 @@ Mac/Linux
     pip install virtualenv
     virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install {{api.name}}-{{api.version}}
+    <your-env>/bin/pip install {{{api.name}}}-{{{api.version}}}
 
 
 Windows
@@ -72,7 +72,7 @@ Windows
     pip install virtualenv
     virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install {{api.name}}-{{api.version}}
+    <your-env>\Scripts\pip.exe install {{{api.name}}}-{{{api.version}}}
 
 
 At this point you are all set to continue.

--- a/templates/gax/python/requirements.txt.mustache
+++ b/templates/gax/python/requirements.txt.mustache
@@ -1,4 +1,4 @@
-googleapis-common-protos>={{dependencies.googleapis_common_protos.python.version}}
-google-gax=={{dependencies.gax.python.version}}
-{{api.dependsOn}}-{{api.version}}>={{api.semantic_version}}
-oauth2client>={{dependencies.auth.python.version}}
+googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}
+google-gax=={{{dependencies.gax.python.version}}}
+{{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}
+oauth2client>={{{dependencies.auth.python.version}}}

--- a/templates/gax/python/setup.py.mustache
+++ b/templates/gax/python/setup.py.mustache
@@ -1,4 +1,4 @@
-"""A setup module for the GAX {{api.titlename}} library.
+"""A setup module for the GAX {{{api.titlename}}} library.
 
 See:
 https://packaging.python.org/en/latest/distributing.html
@@ -9,17 +9,17 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'googleapis-common-protos>={{dependencies.googleapis_common_protos.python.version}}',
-    'google-gax=={{dependencies.gax.python.version}}',
-    '{{api.dependsOn}}-{{api.version}}>={{api.semantic_version}}',
-    'oauth2client>={{dependencies.auth.python.version}}',
+    'googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}',
+    'google-gax=={{{dependencies.gax.python.version}}}',
+    '{{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}',
+    'oauth2client>={{{dependencies.auth.python.version}}}',
 ]
 
 setup(
-    name='{{api.name}}-{{api.version}}',
-    version='{{api.semantic_version}}',
-    author='{{api.author}}',
-    author_email='{{api.email}}',
+    name='{{{api.name}}}-{{{api.version}}}',
+    version='{{{api.semantic_version}}}',
+    author='{{{api.author}}}',
+    author_email='{{{api.email}}}',
     classifiers=[
         'Intended Audience :: Developers',
         'Development Status :: 3 - Alpha',
@@ -29,12 +29,12 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    description='GAX library for the Google {{api.titlename}} API',
+    description='GAX library for the Google {{{api.titlename}}} API',
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=install_requires,
-    license='{{api.license}}',
+    license='{{{api.license}}}',
     packages=find_packages(),
-    namespace_packages=[{{#api.nsPackages}}'{{.}}', {{/api.nsPackages}}],
+    namespace_packages=[{{#api.nsPackages}}'{{{.}}}', {{/api.nsPackages}}],
     url='{{{api.homepage}}}'
 )

--- a/templates/gax/ruby/README.md.mustache
+++ b/templates/gax/ruby/README.md.mustache
@@ -1,21 +1,21 @@
-GAX library for the Google {{api.titlename}} API
+GAX library for the Google {{{api.titlename}}} API
 =================================================
 
-{{api.name}}-{{api.version}} uses [Google API extensions][google-gax] to provide an
-easy-to-use client library for the [Google {{api.titlename}} API][] ({{api.version}}) defined in the [googleapis][] git repository
+{{{api.name}}}-{{{api.version}}} uses [Google API extensions][google-gax] to provide an
+easy-to-use client library for the [Google {{{api.titlename}}} API][] ({{{api.version}}}) defined in the [googleapis][] git repository
 
 
-[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/{{api.path}}/{{api.version}}
+[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/{{{api.path}}}/{{{api.version}}}
 [google-gax]: https://github.com/googleapis/gax-ruby
-[Google {{api.titlename}} API]: https://developers.google.com/apis-explorer/#p/{{api.shortname}}/{{api.version}}/
+[Google {{{api.titlename}}} API]: https://developers.google.com/apis-explorer/#p/{{{api.shortname}}}/{{{api.version}}}/
 
 Getting started
 ---------------
 
-{{api.name}}-{{api.version}} will allow you to connect to the [Google {{api.titlename}} API][] and access all its methods. See the following classes for the actual API access.
+{{{api.name}}}-{{{api.version}}} will allow you to connect to the [Google {{{api.titlename}}} API][] and access all its methods. See the following classes for the actual API access.
 
 {{#api.apiClasses}}
-- [{{name}}](http://www.rubydoc.info/gems/{{api.name}}-{{api.version}}/{{api.semantic_version}}/{{path}})
+- [{{{name}}}](http://www.rubydoc.info/gems/{{{api.name}}}-{{{api.version}}}/{{{api.semantic_version}}}/{{{path}}})
 {{/api.apiClasses}}
 
 In order to achieve so you need to set up authentication as well as install the library locally.
@@ -44,6 +44,6 @@ Installation
 
 Install this library using gem:
 
-    $ [sudo] gem install {{api.name}}-{{api.version}}
+    $ [sudo] gem install {{{api.name}}}-{{{api.version}}}
 
 At this point you are all set to continue.

--- a/templates/gax/ruby/gemspec.mustache
+++ b/templates/gax/ruby/gemspec.mustache
@@ -2,25 +2,25 @@
 # encoding: utf-8
 
 Gem::Specification.new do |s|
-  s.name          = '{{api.name}}-{{api.version}}'
-  s.version       = '{{api.semantic_version}}'
+  s.name          = '{{{api.name}}}-{{{api.version}}}'
+  s.version       = '{{{api.semantic_version}}}'
 
-  s.authors       = ['{{api.author}}']
-  s.description   = '{{api.description}}'
-  s.email         = '{{api.email}}'
+  s.authors       = ['{{{api.author}}}']
+  s.description   = '{{{api.description}}}'
+  s.email         = '{{{api.email}}}'
   s.files         = Dir.glob(File.join('lib', '**', '*.rb'))
   s.files        += Dir.glob(File.join('lib', '**', '*.json'))
   s.files        += %w(Rakefile README.md)
   s.homepage      = '{{{api.homepage}}}'
-  s.license       = '{{api.license}}'
+  s.license       = '{{{api.license}}}'
   s.platform      = Gem::Platform::RUBY
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.0.0'
-  s.summary       = 'GAX library for the {{api.simplename}}-{{api.version}} service'
+  s.summary       = 'GAX library for the {{{api.simplename}}}-{{{api.version}}} service'
 
-  s.add_dependency 'google-gax', '~> {{dependencies.gax.ruby.version}}'
-  s.add_dependency '{{api.dependsOn}}-{{api.version}}', '~>{{api.semantic_version}}'
-  s.add_dependency 'googleapis-common-protos', '~> {{dependencies.googleapis_common_protos.ruby.version}}'
+  s.add_dependency 'google-gax', '~> {{{dependencies.gax.ruby.version}}}'
+  s.add_dependency '{{{api.dependsOn}}}-{{{api.version}}}', '~>{{{api.semantic_version}}}'
+  s.add_dependency 'googleapis-common-protos', '~> {{{dependencies.googleapis_common_protos.ruby.version}}}'
 
   s.add_development_dependency 'bundler', '~> 1.9'
   s.add_development_dependency 'rake', '~> 10.4'

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -10,9 +10,9 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'com.google.protobuf'
 
-description = 'GRPC library for service {{api.name}}-{{api.version}}'
+description = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
 group = "io.gapi"
-version = "{{api.semantic_version}}"
+version = "{{{api.semantic_version}}}"
 // TODO: use a flag to determine whether to produce a release or a snapshot
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/templates/java/build.gradle.mustache
+++ b/templates/java/build.gradle.mustache
@@ -2,9 +2,9 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-description = 'GRPC library for service {{api.name}}-{{api.version}}'
+description = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
 group = "io.gapi"
-version = "{{api.semantic_version}}-SNAPSHOT"
+version = "{{{api.semantic_version}}}-SNAPSHOT"
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
@@ -60,7 +60,7 @@ uploadArchives.repositories.mavenDeployer {
   uploadArchives.repositories.mavenDeployer,
 ]*.pom { pom ->
   pom.project {
-    name "io.gapi:{{api.name}}-{{api.version}}"
+    name "io.gapi:{{{api.name}}}-{{{api.version}}}"
     description project.description
     url '{{{api.homepage}}}'
 
@@ -72,16 +72,16 @@ uploadArchives.repositories.mavenDeployer {
 
     licenses {
       license {
-        name '{{api.license}}'
+        name '{{{api.license}}}'
         url '{{{api.license.url}}}'
       }
     }
 
     developers {
       developer {
-        id "{{api.email}}"
-        name "{{api.author}}"
-        email "{{api.email}}"
+        id "{{{api.email}}}"
+        name "{{{api.author}}}"
+        email "{{{api.email}}}"
         url "{{{api.homepage}}}"
         // https://issues.gradle.org/browse/GRADLE-2719
         organization = "Google, Inc."

--- a/templates/java/settings.gradle.mustache
+++ b/templates/java/settings.gradle.mustache
@@ -1,1 +1,1 @@
-rootProject.name = '{{api.name}}-{{api.version}}'
+rootProject.name = '{{{api.name}}}-{{{api.version}}}'

--- a/templates/nodejs/README.md.mustache
+++ b/templates/nodejs/README.md.mustache
@@ -1,6 +1,6 @@
-# gRPC library for the {{api.simplename}}-{{api.version}} service
+# gRPC library for the {{{api.simplename}}}-{{{api.version}}} service
 
-{{api.name}}-{{api.version}} contains the IDL-generated [grpc][] library for the service: `{{api.simplename}}-{{api.version}}` in the [googleapis][] repository.
+{{{api.name}}}-{{{api.version}}} contains the IDL-generated [grpc][] library for the service: `{{{api.simplename}}}-{{{api.version}}}` in the [googleapis][] repository.
 
 [googleapis]:https://github.com/google/googleapis
 [grpc]:http://www.grpc.io/docs/tutorials/basic/node.html

--- a/templates/nodejs/package.json.mustache
+++ b/templates/nodejs/package.json.mustache
@@ -4,7 +4,7 @@
   "version": "{{{api.semantic_version}}}",
   "author": "Google Inc.",
   "description": "GRPC library for service {{{api.name}}}-{{{api.version}}}",
-  "license": "{{api.license}}",
+  "license": "{{{api.license}}}",
   "dependencies": {
     "grpc": "^{{{dependencies.grpc.nodejs.version}}}",
     "protobufjs": "^{{{dependencies.protobuf.nodejs.version}}}",

--- a/templates/objc/podspec.mustache
+++ b/templates/objc/podspec.mustache
@@ -2,25 +2,25 @@
 # encoding: utf-8
 
 Pod::Spec.new do |s|
-  s.name     = '{{api.name}}-{{api.version}}'
-  s.version  = '{{api.semantic_version}}'
+  s.name     = '{{{api.name}}}-{{{api.version}}}'
+  s.version  = '{{{api.semantic_version}}}'
 
-  s.authors  = { '{{api.author}}' => '{{api.email}}' }
-  s.ios.deployment_target = '{{dependencies.grpc.objc.ios.deployment_target}}'
-  s.osx.deployment_target = '{{dependencies.grpc.objc.osx.deployment_target}}'
-  s.license  = '{{api.license}}'
+  s.authors  = { '{{{api.author}}}' => '{{{api.email}}}' }
+  s.ios.deployment_target = '{{{dependencies.grpc.objc.ios.deployment_target}}}'
+  s.osx.deployment_target = '{{{dependencies.grpc.objc.osx.deployment_target}}}'
+  s.license  = '{{{api.license}}}'
   s.source   = {
     :git => '{{{api.github_user_uri}}}/{{{api.name}}}',
     :tag => "#{s.version}"
   }
-  s.summary  = '{{api.description}}'
+  s.summary  = '{{{api.description}}}'
 
   # The --objc_out plugin generates a pair of .pbobjc.h/.pbobjc.m files for each .proto file.
   s.subspec "Messages" do |ms|
     ms.source_files = "*.pbobjc.{h,m}", "**/*.pbobjc.{h,m}"
     ms.header_mappings_dir = "."
     ms.requires_arc = false
-    ms.dependency "Protobuf", "~> {{dependencies.protobuf.objc.version}}"
+    ms.dependency "Protobuf", "~> {{{dependencies.protobuf.objc.version}}}"
   end
 
   # The --objcgrpc_out plugin generates a pair of .pbrpc.h/.pbrpc.m files for each .proto file with
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     ss.source_files = "*.pbrpc.{h,m}", "**/*.pbrpc.{h,m}"
     ss.header_mappings_dir = "."
     ss.requires_arc = true
-    ss.dependency "gRPC", "~> {{dependencies.grpc.objc.version}}"
+    ss.dependency "gRPC", "~> {{{dependencies.grpc.objc.version}}}"
     ss.dependency "#{s.name}/Messages"
   end
 end

--- a/templates/php/README.md.mustache
+++ b/templates/php/README.md.mustache
@@ -1,6 +1,6 @@
-# gRPC library for the {{api.simplename}}-{{api.version}} service
+# gRPC library for the {{{api.simplename}}}-{{{api.version}}} service
 
-{{api.name}}-{{api.version}} contains the IDL-generated [grpc][] library for the service: `{{api.simplename}}-{{api.version}}` in the [googleapis][] repository.
+{{{api.name}}}-{{{api.version}}} contains the IDL-generated [grpc][] library for the service: `{{{api.simplename}}}-{{{api.version}}}` in the [googleapis][] repository.
 
 [googleapis]:https://github.com/google/googleapis
 [grpc]:http://www.grpc.io/docs/tutorials/basic/php.html

--- a/templates/php/composer.json.mustache
+++ b/templates/php/composer.json.mustache
@@ -1,14 +1,14 @@
 {
-    "name": "google/{{api.name}}-{{api.version}}",
-    "version": "{{api.semantic_version}}",
+    "name": "google/{{{api.name}}}-{{{api.version}}}",
+    "version": "{{{api.semantic_version}}}",
     "type": "library",
-    "description": "GRPC library for the {{api.simplename}}-{{api.version}} service",
+    "description": "GRPC library for the {{{api.simplename}}}-{{{api.version}}} service",
     "keywords": ["google", "grpc"],
     "homepage": "{{{api.homepage}}}",
-    "license": "{{api.license}}",
+    "license": "{{{api.license}}}",
     "authors": [{
-                    "name": "{{api.author}}",
-                    "email": "{{api.email}}"
+                    "name": "{{{api.author}}}",
+                    "email": "{{{api.email}}}"
                 }],
     "require": {
         "php": ">=5.4",

--- a/templates/python/README.rst.mustache
+++ b/templates/python/README.rst.mustache
@@ -1,5 +1,5 @@
-gRPC library for {{api.simplename}}-{{api.version}}
+gRPC library for {{{api.simplename}}}-{{{api.version}}}
 
-{{api.name}}-{{api.version}} is the IDL-derived library for the {{api.simplename}} ({{api.version}}) service in the googleapis_ repository.
+{{{api.name}}}-{{{api.version}}} is the IDL-derived library for the {{{api.simplename}}} ({{{api.version}}}) service in the googleapis_ repository.
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{{{api.path}}}/{{{api.version}}}

--- a/templates/python/setup.py.mustache
+++ b/templates/python/setup.py.mustache
@@ -1,4 +1,4 @@
-"""A setup module for the GRPC {{api.simplename}} service.
+"""A setup module for the GRPC {{{api.simplename}}} service.
 
 See:
 https://packaging.python.org/en/latest/distributing.html
@@ -10,16 +10,16 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
-  'oauth2client>={{dependencies.auth.python.version}}',
-  'grpcio>={{dependencies.grpc.python.version}}',
-  'googleapis-common-protos>={{dependencies.googleapis_common_protos.python.version}}'
+  'oauth2client>={{{dependencies.auth.python.version}}}',
+  'grpcio>={{{dependencies.grpc.python.version}}}',
+  'googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}'
 ]
 
 setuptools.setup(
-  name='{{api.name}}-{{api.version}}',
-  version='{{api.semantic_version}}',
-  author='{{api.author}}',
-  author_email='{{api.email}}',
+  name='{{{api.name}}}-{{{api.version}}}',
+  version='{{{api.semantic_version}}}',
+  author='{{{api.author}}}',
+  author_email='{{{api.email}}}',
   classifiers=[
     'Intended Audience :: Developers',
     'Development Status :: 3 - Alpha',
@@ -29,11 +29,11 @@ setuptools.setup(
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: Implementation :: CPython',
   ],
-  description='GRPC library for the {{api.simplename}}-{{api.version}} service',
+  description='GRPC library for the {{{api.simplename}}}-{{{api.version}}} service',
   long_description=open('README.rst').read(),
   install_requires=install_requires,
-  license='{{api.license}}',
+  license='{{{api.license}}}',
   packages=find_packages(),
-  namespace_packages=[{{#api.nsPackages}}'{{.}}', {{/api.nsPackages}}],
+  namespace_packages=[{{#api.nsPackages}}'{{{.}}}', {{/api.nsPackages}}],
   url='{{{api.homepage}}}'
 )

--- a/templates/ruby/gemspec.mustache
+++ b/templates/ruby/gemspec.mustache
@@ -2,24 +2,24 @@
 # encoding: utf-8
 
 Gem::Specification.new do |s|
-  s.name          = '{{api.name}}-{{api.version}}'
-  s.version       = '{{api.semantic_version}}'
+  s.name          = '{{{api.name}}}-{{{api.version}}}'
+  s.version       = '{{{api.semantic_version}}}'
 
-  s.authors       = ['{{api.author}}']
-  s.description   = '{{api.description}}'
-  s.email         = '{{api.email}}'
+  s.authors       = ['{{{api.author}}}']
+  s.description   = '{{{api.description}}}'
+  s.email         = '{{{api.email}}}'
   s.files         = Dir.glob(File.join('lib', '**', '*.rb'))
   s.homepage      = '{{{api.homepage}}}'
-  s.license       = '{{api.license}}'
+  s.license       = '{{{api.license}}}'
   s.platform      = Gem::Platform::RUBY
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.0.0'
-  s.requirements << 'libgrpc ~> {{dependencies.grpc.core.version}} needs to be installed'
-  s.summary       = 'GRPC library for service {{api.name}}-{{api.version}}'
+  s.requirements << 'libgrpc ~> {{{dependencies.grpc.core.version}}} needs to be installed'
+  s.summary       = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
 
-  s.add_dependency 'grpc', '~> {{dependencies.grpc.ruby.version}}'
-  s.add_dependency 'googleauth', '~> {{dependencies.auth.ruby.version}}'
-  s.add_dependency 'googleapis-common-protos', '~> {{dependencies.googleapis_common_protos.ruby.version}}'
+  s.add_dependency 'grpc', '~> {{{dependencies.grpc.ruby.version}}}'
+  s.add_dependency 'googleauth', '~> {{{dependencies.auth.ruby.version}}}'
+  s.add_dependency 'googleapis-common-protos', '~> {{{dependencies.googleapis_common_protos.ruby.version}}}'
 
   s.add_development_dependency 'bundler', '~> 1.9'
   s.add_development_dependency 'rake', '~> 10.4'


### PR DESCRIPTION
Don't think we ever want HTML escaping, and having it on by default
causes problems whenever API names contain, e.g., a hyphen.