### PR TITLE
Allow a range of point versions for gax-python

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -45,6 +45,7 @@ grpc:
 gax:
   python:
     version: '0.12.3'
+    next_version: '0.13.0'
   ruby:
     version: '0.4.1'
   nodejs:

--- a/templates/gax/python/requirements.txt.mustache
+++ b/templates/gax/python/requirements.txt.mustache
@@ -1,4 +1,4 @@
 googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}
-google-gax=={{{dependencies.gax.python.version}}}
+google-gax>={{{dependencies.gax.python.version}}}, <{{{dependencies.gax.python.next_version}}}
 {{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}
 oauth2client>={{{dependencies.auth.python.version}}}

--- a/templates/gax/python/setup.py.mustache
+++ b/templates/gax/python/setup.py.mustache
@@ -10,7 +10,7 @@ import sys
 
 install_requires = [
     'googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}',
-    'google-gax=={{{dependencies.gax.python.version}}}',
+    'google-gax>={{{dependencies.gax.python.version}}}, <{{{dependencies.gax.python.next_version}}}',
     '{{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}',
     'oauth2client>={{{dependencies.auth.python.version}}}',
 ]


### PR DESCRIPTION
Previously, the version was pegged. This way should prevent issues
like https://github.com/GoogleCloudPlatform/gcloud-python/issues/1979

FYI @bjwatson 