### PR TITLE
Fix gax-generated code path from src to lib.

### DIFF
--- a/lib/packager.js
+++ b/lib/packager.js
@@ -405,7 +405,7 @@ function makeNodejsPackage(opts, done) {
     // For tests, mock data is passed instead of scanning the filesystem.
     runTask(null, opts.mockApiFilesForTest);
   } else {
-    glob.glob('*.js', {cwd: path.join(opts.top, 'lib')}, runTask);
+    glob.glob('*.js', {cwd: path.join(opts.top, 'src')}, runTask);
   }
 }
 

--- a/templates/gax/nodejs/index.js.mustache
+++ b/templates/gax/nodejs/index.js.mustache
@@ -15,7 +15,7 @@
  */
 
 {{#apiFiles}}
-var apiClient = require('./lib/{{{.}}}');
+var apiClient = require('./src/{{{.}}}');
 for (var key in apiClient) {
   exports[key] = apiClient[key];
 }

--- a/test/fixtures/gax/nodejs/index.js
+++ b/test/fixtures/gax/nodejs/index.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-var apiClient = require('./lib/foo_api');
+var apiClient = require('./src/foo_api');
 for (var key in apiClient) {
   exports[key] = apiClient[key];
 }
-var apiClient = require('./lib/bar_api');
+var apiClient = require('./src/bar_api');
 for (var key in apiClient) {
   exports[key] = apiClient[key];
 }


### PR DESCRIPTION
This is necessary due to the change in https://github.com/googleapis/toolkit/pull/351