### PR TITLE
Bump Python GAX version

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -30,6 +30,6 @@ semver:
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.8.0'
+  python: '0.8.1'
   ruby: '0.6.8'
   php: '0.6.0'

--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -30,6 +30,6 @@ semver:
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.7.13'
+  python: '0.8.0'
   ruby: '0.6.8'
   php: '0.6.0'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -44,7 +44,7 @@ grpc:
 
 gax:
   python:
-    version: '0.12.4'
+    version: '0.12.5'
     next_version: '0.13.0'
   ruby:
     version: '0.4.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-packman",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "bin": {
     "gen-api-package": "bin/gen-api-package"
   },


### PR DESCRIPTION
Corresponds to https://github.com/googleapis/gax-python/pull/122