### PR TITLE
Java: supporting common protos package with compiled classes

### DIFF
--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -244,12 +244,10 @@ var parsePlugins = function parsePlugins(pluginSpecs) {
  */
 var main = function main() {
   var opts = parseArgs();
-  if (opts.buildCommonProtos) {
-    if (!opts.altJava) {
-      opts.pkgPrefix = 'googleapis-common-protos';
-      opts.apiName = 'googleapis-common-protos';
-      opts.apiVersion = '';
-    }
+  if (opts.buildCommonProtos && !opts.altJava) {
+    opts.pkgPrefix = 'googleapis-common-protos';
+    opts.apiName = 'googleapis-common-protos';
+    opts.apiVersion = '';
   }
   if (opts.overridePlugins) {
     opts.overridePlugins = parsePlugins(opts.overridePlugins);

--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -245,9 +245,11 @@ var parsePlugins = function parsePlugins(pluginSpecs) {
 var main = function main() {
   var opts = parseArgs();
   if (opts.buildCommonProtos) {
-    opts.pkgPrefix = 'googleapis-common-protos';
-    opts.apiName = 'googleapis-common-protos';
-    opts.apiVersion = '';
+    if (!opts.altJava) {
+      opts.pkgPrefix = 'googleapis-common-protos';
+      opts.apiName = 'googleapis-common-protos';
+      opts.apiVersion = '';
+    }
   }
   if (opts.overridePlugins) {
     opts.overridePlugins = parsePlugins(opts.overridePlugins);
@@ -280,7 +282,7 @@ var main = function main() {
   repo.on('ready', function() {
     if (opts.gaxDir) {
       repo.buildGaxPackages(apiName, apiVersion);
-    } else if (opts.buildCommonProtos) {
+    } else if (opts.buildCommonProtos && !opts.altJava) {
       repo.buildCommonProtoPkgs();
     } else {
       repo.buildPackages(apiName, apiVersion);

--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -24,7 +24,7 @@ license: Apache-2.0
 semver:
   go: '0.6.0'
   objc: '0.6.0'
-  java: '0.6.0'
+  java: '0.0.7'
   nodejs: '0.7.1'
   # TODO: Python must go to 1.0.20 or 1.1.0 when we GA, due to mistakenly
   #       publishing some 1.0.x versions to pypi already. They are now

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -41,6 +41,8 @@ grpc:
     version: '0.15.0'
   php:
     version: '0.14.1'
+  java:
+    version: '0.15.0'
 
 gax:
   python:
@@ -59,6 +61,9 @@ protobuf:
   nodejs:
     # This is the version of ProtoBuf.js.
     version: '5.0.1'
+  java:
+    # Technically, this is the version for for protobuf-java
+    version: '3.0.0-beta-3'
 
 googleapis_common_protos:
   python:

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -77,7 +77,7 @@ function ApiRepo(opts) {
   this.pkgPrefix = opts.pkgPrefix;
   this.overridePlugins = opts.overridePlugins;
   this.zipUrl = opts.zipUrl;
-  this.isGoogleApi = (!!opts.buildCommonProtos && !opts.altJava)
+  this.isGoogleApi = (!!opts.buildCommonProtos && !opts.altJava);
   if (_.isEmpty(this.repoDirs) && !this.zipUrl) {
     this.zipUrl = GOOGLE_APIS_REPO_ZIP; // default to download googleapis
     this.isGoogleApi = true;
@@ -201,7 +201,6 @@ ApiRepo.prototype.buildPackages =
       var that = this;
       var done = this._wrapDone(optDone);
       var altJava = this.opts.altJava;
-      var buildCommonProtos = this.opts.buildCommonProtos;
 
       var templateInfo = rootTemplateDir(
           defaultTemplateInfo, this.templateRoot);
@@ -227,7 +226,8 @@ ApiRepo.prototype.buildPackages =
                 cleanName.replace(new RegExp('-', 'g'), '/');
             opts.packageInfo.api.name = that.pkgPrefix + cleanName;
             opts.packageInfo.api.version = version;
-            opts.packageInfo.api.buildCommonProtos = buildCommonProtos;
+            opts.packageInfo.api.buildCommonProtos =
+                that.opts.buildCommonProtos;
             var semver = opts.packageInfo.api.semver[l];
             if (semver) {
               /* eslint-disable camelcase */

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -77,7 +77,7 @@ function ApiRepo(opts) {
   this.pkgPrefix = opts.pkgPrefix;
   this.overridePlugins = opts.overridePlugins;
   this.zipUrl = opts.zipUrl;
-  this.isGoogleApi = !!opts.buildCommonProtos;
+  this.isGoogleApi = (!!opts.buildCommonProtos && !opts.altJava)
   if (_.isEmpty(this.repoDirs) && !this.zipUrl) {
     this.zipUrl = GOOGLE_APIS_REPO_ZIP; // default to download googleapis
     this.isGoogleApi = true;
@@ -201,6 +201,7 @@ ApiRepo.prototype.buildPackages =
       var that = this;
       var done = this._wrapDone(optDone);
       var altJava = this.opts.altJava;
+      var buildCommonProtos = this.opts.buildCommonProtos;
 
       var templateInfo = rootTemplateDir(
           defaultTemplateInfo, this.templateRoot);
@@ -226,6 +227,7 @@ ApiRepo.prototype.buildPackages =
                 cleanName.replace(new RegExp('-', 'g'), '/');
             opts.packageInfo.api.name = that.pkgPrefix + cleanName;
             opts.packageInfo.api.version = version;
+            opts.packageInfo.api.buildCommonProtos = buildCommonProtos;
             var semver = opts.packageInfo.api.semver[l];
             if (semver) {
               /* eslint-disable camelcase */

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -10,27 +10,29 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'com.google.protobuf'
 
-description = 'GRPC library for service {{{api.name}}}-{{{api.version}}}'
+{{#api.buildCommonProtos}}
+description = 'GRPC library for core Google API protos'
+{{/api.buildCommonProtos}}
+{{^api.buildCommonProtos}}
+description = 'GRPC library for {{{api.name}}}-{{{api.version}}}'
+{{/api.buildCommonProtos}}
 group = "com.google.api.grpc"
 version = "{{{api.semantic_version}}}"
 // TODO: use a flag to determine whether to produce a release or a snapshot
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
-def tmpSnapshotRepo = "http://104.197.230.53:8081/nexus/content/repositories/snapshots/"
 
 repositories {
   mavenCentral()
   mavenLocal()
-  maven {
-    // Private maven repo.  Temporary, until googleapis-common-protos is published
-    url tmpSnapshotRepo
-  }
 }
 
 dependencies {
-  compile "com.google.protobuf:protobuf-java:3.0.0-beta-3"
-  compile "io.gapi:googleapis-common-protos:0.0.0-SNAPSHOT"
-  compile "io.grpc:grpc-all:0.15.0"
+  compile "com.google.protobuf:protobuf-java:{{{dependencies.protobuf.java.version}}}"
+  {{^api.buildCommonProtos}}
+  compile "com.google.api.grpc:grpc-google-common-protos:{{{api.semantic_version}}}"
+  {{/api.buildCommonProtos}}
+  compile "io.grpc:grpc-all:{{{dependencies.grpc.java.version}}}"
 }
 
 protobuf {
@@ -38,11 +40,11 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = "com.google.protobuf:protoc:3.0.0-beta-3"
+    artifact = "com.google.protobuf:protoc:{{{dependencies.protobuf.java.version}}}"
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:0.15.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:{{{dependencies.grpc.java.version}}}'
     }
   }
   generateProtoTasks {
@@ -94,7 +96,12 @@ if (rootProject.hasProperty('mavenRepoUrl')) {
     }
     repository(url: mavenRepoUrl, configureAuth)
     pom.project {
-      name "com.google.api.grpc:grpc-{{{api.name}}}-{{{api.version}}}"
+      {{#api.buildCommonProtos}}
+      name "com.google.api.grpc:grpc-google-common-protos"
+      {{/api.buildCommonProtos}}
+      {{^api.buildCommonProtos}}
+      name "com.google.api.grpc:{{{api.name}}}-{{{api.version}}}"
+      {{/api.buildCommonProtos}}
       description project.description
       url 'https://github.com/googleapis/googleapis'
       scm {

--- a/templates/java/build.gradle.mustache
+++ b/templates/java/build.gradle.mustache
@@ -14,8 +14,8 @@ repositories {
 }
 
 dependencies {
-  compile "com.google.protobuf:protobuf-java:3.0.0-beta-3"
-  compile "io.gapi:googleapis-common-protos:0.0.0-SNAPSHOT"
+  compile "com.google.protobuf:protobuf-java:{{{dependencies.protobuf.java.version}}}"
+  compile "com.google.api.grpc:googleapis-common-protos:0.0.3"
 }
 
 task javadocJar(type: Jar) {

--- a/test/fixtures/java/build.gradle
+++ b/test/fixtures/java/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
   compile "com.google.protobuf:protobuf-java:3.0.0-beta-3"
-  compile "io.gapi:googleapis-common-protos:0.0.0-SNAPSHOT"
+  compile "com.google.api.grpc:googleapis-common-protos:0.0.3"
 }
 
 task javadocJar(type: Jar) {

--- a/test/packager.js
+++ b/test/packager.js
@@ -126,6 +126,9 @@ var testPackageInfo = {
       },
       nodejs: {
         version: '5.0.1'
+      },
+      java: {
+        version: '3.0.0-beta-3'
       }
     },
     googleapis_common_protos: {


### PR DESCRIPTION
This is so that we can switch artman to use packman for JavaCorePipeline instead of the proto generation inside artman. 