### PR TITLE
Allow protoc to be injected

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ usage: gen-api-package [-h] [-v] [-x] [-i INCLUDEPATH] [-o OUTDIR]
                        [--package_prefix PKGPREFIX]
                        [--template_root TEMPLATEROOT]
                        [--override_plugins OVERRIDEPLUGINS]
+                       [--proto_compiler PROTOCOMPILER]
+                       [--proto_compiler_args PROTOCOMPILERARGS]
 
 
 Creates packages for gRPC services.
@@ -125,4 +127,10 @@ Optional arguments:
                         grpc_python_plugin. This can be modified by
                         specifying --override_plugins
                         python=other_rpc_python_plugin.
+  --proto_compiler PROTOCOMPILER
+                       Specifies the proto compiler to be used, if not protoc
+                       Defaults to protoc.
+  --proto_compiler_args PROTOCOMPILERARGS
+                       Specifies arguments that always should be passed to the
+                       proto compiler
 ```

--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -220,6 +220,22 @@ var parseArgs = function parseArgs() {
       dest: 'overridePlugins'
     }
   );
+  cli.addArgument(
+    [ '--proto_compiler' ],
+    {
+      help: 'Specifies the proto compiler to be used, if not protoc\n' +
+            ' Defaults to protoc.',
+      dest: 'protoCompiler'
+    }
+  );
+  cli.addArgument(
+    [ '--proto_compiler_args' ],
+    {
+      help: 'Specifies arguments that always should be passed to the\n' +
+            ' proto compiler.',
+      dest: 'protoCompilerArgs'
+    }
+  );
   return cli.parseArgs();
 };
 

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -78,7 +78,7 @@ function ApiRepo(opts) {
   this.repoDirs = opts.repoDirs || [];
   this.templateRoot = opts.templateRoot;
   this.protoCompiler = opts.protoCompiler || DEFAULT_PROTO_COMPILER;
-  this.protoCompilerArgs = opts.protoCompilerArgs || [];
+  this.protoCompilerArgs = opts.protoCompilerArgs || '';
   this.pkgPrefix = opts.pkgPrefix;
   this.overridePlugins = opts.overridePlugins;
   this.zipUrl = opts.zipUrl;
@@ -427,7 +427,8 @@ ApiRepo.prototype.buildCommonProtoPkgs =
  * @param {string} protoFile - The target .proto file.
  * @param {function(?Error, string[])} done - The callback.
  */
-function collectProtoDeps(includePath, protoFile, done) {
+ApiRepo.prototype._collectProtoDeps = function _collectProtoDeps(
+    includePath, protoFile, done) {
   var deps = tmp.fileSync();
   var desc = tmp.fileSync();
   var args = this.protoCompilerArgs.concat(
@@ -464,7 +465,7 @@ function collectProtoDeps(includePath, protoFile, done) {
  *
  * @param {Array.<Array<string>>} fileLists - - the list of the lists of the
  *   .proto files to be copied. Each item is the list of .proto files calculated
- *   by collectProtoDeps.
+ *   by _collectProtoDeps.
  * @param {string[]} includePath - - the list of include paths used for protoc.
  * @return {Object} - an object whose keys are the source files (i.e. items
  *   in fileList) and values are the path of the files relative to
@@ -567,7 +568,8 @@ ApiRepo.prototype._buildProtos =
             function makeProtoBasedNodeModule(fullPathProtos, includePath) {
               var outDir = path.join(langTopDir, 'proto');
               async.map(
-                  fullPathProtos, collectProtoDeps.bind(null, includePath),
+                  fullPathProtos,
+                  this._collectProtoDeps.bind(null, includePath),
                   function(err, fileLists) {
                     if (err) {
                       findOutputs(err);
@@ -988,6 +990,7 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         return;
       }
       fs.mkdirsSync(outDir);
+      console.log('args', that.protoCompilerArgs)
       var args = that.protoCompilerArgs.split(' ');
       if (language === 'go') {
         args.push('--' + language + '_out=plugins=grpc:' + outDir);

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -455,7 +455,7 @@ ApiRepo.prototype._collectProtoDeps = function _collectProtoDeps(
       done(null, data.replace(/^\s+/, '').replace(/\\\n/mg, ' ').split(/\s+/m));
     });
   });
-}
+};
 
 /**
  * Create the mapping of the .proto file source to the destination.
@@ -990,7 +990,6 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         return;
       }
       fs.mkdirsSync(outDir);
-      console.log('args', that.protoCompilerArgs)
       var args = that.protoCompilerArgs.split(' ');
       if (language === 'go') {
         args.push('--' + language + '_out=plugins=grpc:' + outDir);

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -50,8 +50,11 @@ var DEFAULT_LANGUAGES = [
   'php'
 ];
 
-// nodejs builds using ProtoBuf.js, and the Java package just copies protos.
-var NO_PROTOC_PLUGIN = ['nodejs', 'java'];
+var DEFAULT_PROTO_COMPILER = 'protoc';
+
+// nodejs builds using ProtoBuf.js. The Java package just copies protos.
+// Python builds using grpcio-tools.
+var NO_PROTOC_PLUGIN = ['nodejs', 'java', 'python'];
 
 // the default include path, where install the protobuf runtime installs its
 // protos.
@@ -74,6 +77,8 @@ function ApiRepo(opts) {
   this.gaxDir = opts.gaxDir;
   this.repoDirs = opts.repoDirs || [];
   this.templateRoot = opts.templateRoot;
+  this.protoCompiler = opts.protoCompiler || DEFAULT_PROTO_COMPILER;
+  this.protoCompilerArgs = opts.protoCompilerArgs || [];
   this.pkgPrefix = opts.pkgPrefix;
   this.overridePlugins = opts.overridePlugins;
   this.zipUrl = opts.zipUrl;
@@ -425,7 +430,8 @@ ApiRepo.prototype.buildCommonProtoPkgs =
 function collectProtoDeps(includePath, protoFile, done) {
   var deps = tmp.fileSync();
   var desc = tmp.fileSync();
-  var args = ['--dependency_out=' + deps.name, '-o', desc.name];
+  var args = this.protoCompilerArgs.concat(
+      ['--dependency_out=' + deps.name, '-o', desc.name]);
   if (includePath) {
     includePath.forEach(function(ipath) {
       args.push('-I', ipath);
@@ -434,7 +440,7 @@ function collectProtoDeps(includePath, protoFile, done) {
   args.push(protoFile);
   // Invokes protoc with --dependency_out to generate the dependency
   // proto files.
-  execFile('protoc', args, {}, function(err) {
+  execFile(this.protoCompiler, args, {}, function(err) {
     if (err) {
       done(err);
     }
@@ -668,7 +674,7 @@ ApiRepo.prototype._checkDeps = function _checkDeps(opts, done) {
 
   opts = opts || {};
   opts.env = opts.env || this.opts.env || process.env;
-  var reqdBins = ['protoc'];
+  var reqdBins = [this.protoCompiler];
   var that = this;
   this.languages.forEach(function(l) {
     if (_.includes(NO_PROTOC_PLUGIN, l)) {
@@ -982,7 +988,7 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         return;
       }
       fs.mkdirsSync(outDir);
-      var args = [];
+      var args = that.protoCompilerArgs.split(' ');
       if (language === 'go') {
         args.push('--' + language + '_out=plugins=grpc:' + outDir);
       } else {
@@ -1000,7 +1006,8 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
             args.push('--grpc_out=' + outDir);
           }
         }
-        if (!opts.buildCommonProtos) {
+        if (!(opts.buildCommonProtos ||
+              _.includes(NO_PROTOC_PLUGIN, language))) {
           var pluginBin = that.depBins[
               that._getPluginName(language, that.overridePlugins)];
           args.push(pluginOption + pluginBin);
@@ -1014,7 +1021,7 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
 
       // Spawn the protoc command.
       console.log('exec: protoc %s\n in %s', args, repoDir);
-      execFile('protoc', args, {
+      execFile(that.protoCompiler, args, {
         cwd: protocCwd,
         env: opts.env
       }, done);

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -424,7 +424,7 @@ describe('ApiRepo', function() {
       }, 'go');
       protoc(fullFakeDir, fakeProto, passesOn(done));
     });
-    it('should fail if func that runs alternative protoc', function(done) {
+    it('should fail if alternative protoc is not on path', function(done) {
       var otherRepo = new ApiRepo({
         protoCompiler: 'custom',
         protoCompilerArgs: '--some arg'

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -374,7 +374,6 @@ describe('ApiRepo', function() {
             repo.outDir, 'python');
         want += ' --grpc_out=' + path.join(
             repo.outDir, 'python');
-        want += ' --plugin=protoc-gen-grpc=/testing/bin/my_python_plugin';
         want += ' -I.';
         want += ' -I/usr/local/include';
         want += ' ' + path.join(fakePackageDirectory, fakeProto) + '\n';
@@ -398,7 +397,6 @@ describe('ApiRepo', function() {
                repo.outDir, 'python');
            want += ' --grpc_out=' + path.join(
                repo.outDir, 'python');
-           want += ' --plugin=protoc-gen-grpc=/testing/bin/my_python_plugin';
            want += ' -I.';
            want += ' -I/an/include/path';
            want += ' -I/another/include/path';
@@ -415,6 +413,27 @@ describe('ApiRepo', function() {
          }, 'python');
          protoc(fullFakeDir, fakeProto, shouldPass);
        });
+    it('should obtain a func that runs alternative protoc', function(done) {
+      var otherRepo = new ApiRepo({
+        protoCompiler: 'custom',
+        protoCompilerArgs: '--some arg'
+      });
+      var otherFakes = addFakeBinsToPath('custom');
+      var protoc = otherRepo._makeProtocFunc({
+        env: {PATH: otherFakes.path}
+      }, 'go');
+      protoc(fullFakeDir, fakeProto, passesOn(done));
+    });
+    it('should fail if func that runs alternative protoc', function(done) {
+      var otherRepo = new ApiRepo({
+        protoCompiler: 'custom',
+        protoCompilerArgs: '--some arg'
+      });
+      var protoc = otherRepo._makeProtocFunc({
+        env: {PATH: fakes.path}
+      }, 'go');
+      protoc(fullFakeDir, fakeProto, errsOn(done));
+    });
     it('should obtain a func that runs protoc for GoLang', function(done) {
       var shouldPass = function(err, got) {
         expect(err).to.be.null();


### PR DESCRIPTION
This allows packman to support languages like Python, where the
official way of doing grpc codegen is through a Python wrapper around
protoc.

Updates googleapis/gax-python#126