### PR TITLE
Java generation: supporting dependencies option

### DIFF
--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -236,6 +236,15 @@ var parseArgs = function parseArgs() {
       dest: 'protoCompilerArgs'
     }
   );
+  cli.addArgument(
+    [ '--dependencies' ],
+    {
+      action: 'append',
+      help: 'Specifies the dependencies on other packages containing\n'
+            + ' proto-generated code.',
+      dest: 'dependencies'
+    }
+  );
   return cli.parseArgs();
 };
 

--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -237,12 +237,12 @@ var parseArgs = function parseArgs() {
     }
   );
   cli.addArgument(
-    [ '--dependencies' ],
+    [ '--proto_gen_pkg_dep' ],
     {
       action: 'append',
-      help: 'Specifies the dependencies on other packages containing\n'
-            + ' proto-generated code.',
-      dest: 'dependencies'
+      help: 'Specifies the dependencies on other packages generated\n'
+            + ' by packman, containing proto-generated code.',
+      dest: 'protoGenPackageDeps'
     }
   );
   return cli.parseArgs();

--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -24,7 +24,7 @@ license: Apache-2.0
 semver:
   go: '0.6.0'
   objc: '0.6.0'
-  java: '0.0.7'
+  java: '0.0.9'
   nodejs: '0.7.1'
   # TODO: Python must go to 1.0.20 or 1.1.0 when we GA, due to mistakenly
   #       publishing some 1.0.x versions to pypi already. They are now

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -242,8 +242,9 @@ ApiRepo.prototype.buildPackages =
               opts.packageInfo.api.semantic_version = semver;
               /* eslint-enable camelcase */
             }
-            if (that.opts.dependencies) {
-              opts.packageInfo.api.dependencies = that.opts.dependencies.map(function(dep) {
+            if (that.opts.protoGenPackageDeps) {
+              opts.packageInfo.api.protoGenPackageDeps =
+                  that.opts.protoGenPackageDeps.map(function(dep) {
                 return that.pkgPrefix + dep;
               });
             }

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -244,6 +244,9 @@ ApiRepo.prototype.buildPackages =
               /* eslint-enable camelcase */
             }
             if (that.opts.protoGenPackageDeps) {
+              // TODO convert to a method which allows for differing logic
+              // between languages (e.g. Python/Ruby don't use the prefix
+              // for googleapis-common-protos)
               opts.packageInfo.api.protoGenPackageDeps =
                   that.opts.protoGenPackageDeps.map(function(dep) {
                     return that.pkgPrefix + dep;

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -231,13 +231,21 @@ ApiRepo.prototype.buildPackages =
                 cleanName.replace(new RegExp('-', 'g'), '/');
             opts.packageInfo.api.name = that.pkgPrefix + cleanName;
             opts.packageInfo.api.version = version;
-            opts.packageInfo.api.buildCommonProtos =
-                that.opts.buildCommonProtos;
+            if (version) {
+              opts.packageInfo.api.fullName = opts.packageInfo.api.name + '-' + version;
+            } else {
+              opts.packageInfo.api.fullName = opts.packageInfo.api.name;
+            }
             var semver = opts.packageInfo.api.semver[l];
             if (semver) {
               /* eslint-disable camelcase */
               opts.packageInfo.api.semantic_version = semver;
               /* eslint-enable camelcase */
+            }
+            if (that.opts.dependencies) {
+              opts.packageInfo.api.dependencies = that.opts.dependencies.map(function(dep) {
+                return that.pkgPrefix + dep;
+              });
             }
             packager[l](opts, next);
           };

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -232,7 +232,8 @@ ApiRepo.prototype.buildPackages =
             opts.packageInfo.api.name = that.pkgPrefix + cleanName;
             opts.packageInfo.api.version = version;
             if (version) {
-              opts.packageInfo.api.fullName = opts.packageInfo.api.name + '-' + version;
+              opts.packageInfo.api.fullName =
+                  opts.packageInfo.api.name + '-' + version;
             } else {
               opts.packageInfo.api.fullName = opts.packageInfo.api.name;
             }
@@ -245,8 +246,8 @@ ApiRepo.prototype.buildPackages =
             if (that.opts.protoGenPackageDeps) {
               opts.packageInfo.api.protoGenPackageDeps =
                   that.opts.protoGenPackageDeps.map(function(dep) {
-                return that.pkgPrefix + dep;
-              });
+                    return that.pkgPrefix + dep;
+                  });
             }
             packager[l](opts, next);
           };

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -24,9 +24,9 @@ repositories {
 
 dependencies {
   compile "com.google.protobuf:protobuf-java:{{{dependencies.protobuf.java.version}}}"
-  {{#api.dependencies}}
+  {{#api.protoGenPackageDeps}}
   compile "com.google.api.grpc:{{{.}}}:{{{api.semantic_version}}}"
-  {{/api.dependencies}}
+  {{/api.protoGenPackageDeps}}
   compile "io.grpc:grpc-all:{{{dependencies.grpc.java.version}}}"
 }
 

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -10,12 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'com.google.protobuf'
 
-{{#api.buildCommonProtos}}
-description = 'GRPC library for core Google API protos'
-{{/api.buildCommonProtos}}
-{{^api.buildCommonProtos}}
-description = 'GRPC library for {{{api.name}}}-{{{api.version}}}'
-{{/api.buildCommonProtos}}
+description = 'GRPC library for {{{api.fullName}}}'
 group = "com.google.api.grpc"
 version = "{{{api.semantic_version}}}"
 // TODO: use a flag to determine whether to produce a release or a snapshot
@@ -29,9 +24,9 @@ repositories {
 
 dependencies {
   compile "com.google.protobuf:protobuf-java:{{{dependencies.protobuf.java.version}}}"
-  {{^api.buildCommonProtos}}
-  compile "com.google.api.grpc:grpc-google-common-protos:{{{api.semantic_version}}}"
-  {{/api.buildCommonProtos}}
+  {{#api.dependencies}}
+  compile "com.google.api.grpc:{{{.}}}:{{{api.semantic_version}}}"
+  {{/api.dependencies}}
   compile "io.grpc:grpc-all:{{{dependencies.grpc.java.version}}}"
 }
 
@@ -96,12 +91,7 @@ if (rootProject.hasProperty('mavenRepoUrl')) {
     }
     repository(url: mavenRepoUrl, configureAuth)
     pom.project {
-      {{#api.buildCommonProtos}}
-      name "com.google.api.grpc:grpc-google-common-protos"
-      {{/api.buildCommonProtos}}
-      {{^api.buildCommonProtos}}
-      name "com.google.api.grpc:{{{api.name}}}-{{{api.version}}}"
-      {{/api.buildCommonProtos}}
+      name "com.google.api.grpc:{{{api.fullName}}}"
       description project.description
       url 'https://github.com/googleapis/googleapis'
       scm {


### PR DESCRIPTION
This allows common protos to use the same code path as grpc packages, so
the build_common_protos option doesn't need to be passed.