### PR TITLE
Fix protoc arguments.

### DIFF
--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -1003,7 +1003,7 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         return;
       }
       fs.mkdirsSync(outDir);
-      var args = that.protoCompilerArgs.split(' ');
+      var args = that.protoCompilerArgs ? that.protoCompilerArgs.split(' ') : [];
       if (language === 'go') {
         args.push('--' + language + '_out=plugins=grpc:' + outDir);
       } else {


### PR DESCRIPTION
protoc commandline invocation fails when protoCompilerArgs is
empty (i.e. prevent adding an empty string '' as a parameter).

Fixes #101.