### PR TITLE
Fix GRPC python gen issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore backup files
 *~
 
+# Build results
+src-gen
+
 # Logs
 logs
 *.log
@@ -32,3 +35,6 @@ node_modules
 # Eclipse files
 .project
 .pydevproject
+
+# Ctags
+tags

--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -313,6 +313,7 @@ var main = function main() {
   });
   repo.on('error', function(err) {
     console.error('Could not build packages:', err);
+    process.exit(1);
   });
   repo.setUp();
 }

--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -30,6 +30,6 @@ semver:
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.8.1'
+  python: '0.9.0'
   ruby: '0.6.8'
   php: '0.6.0'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -34,7 +34,7 @@ grpc:
     osx:
       deployment_target: '10.8'
   python:
-    version: '1.0rc2'
+    version: '1.0.0'
   ruby:
     version: '1.0'
   nodejs:
@@ -55,7 +55,7 @@ gax:
 
 protobuf:
   python:
-    version: '3.0.0b3'
+    version: '3.0.0'
   ruby:
     version: '3.0'
   nodejs:
@@ -67,7 +67,7 @@ protobuf:
 
 googleapis_common_protos:
   python:
-    version: '1.1.0'
+    version: '1.2.0'
   ruby:
     version: '1.2.0'
 

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -1018,7 +1018,12 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         } else {
           args.push('--' + language + '_out=' + outDir);
           if (!opts.buildCommonProtos) {
-            args.push('--grpc_out=' + outDir);
+            if (language === 'python') {
+              // required per https://github.com/grpc/grpc/issues/7857
+              args.push('--grpc_python_out=' + outDir);
+            } else {
+              args.push('--grpc_out=' + outDir);
+            }
           }
         }
         if (!(opts.buildCommonProtos ||

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -1003,7 +1003,8 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         return;
       }
       fs.mkdirsSync(outDir);
-      var args = that.protoCompilerArgs ? that.protoCompilerArgs.split(' ') : [];
+      var args = that.protoCompilerArgs ?
+          that.protoCompilerArgs.split(' ') : [];
       if (language === 'go') {
         args.push('--' + language + '_out=plugins=grpc:' + outDir);
       } else {

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -372,7 +372,7 @@ describe('ApiRepo', function() {
         // The test uses the fake protoc, so it just echoes its args
         var want = '--python_out=' + path.join(
             repo.outDir, 'python');
-        want += ' --grpc_out=' + path.join(
+        want += ' --grpc_python_out=' + path.join(
             repo.outDir, 'python');
         want += ' -I.';
         want += ' -I/usr/local/include';
@@ -395,7 +395,7 @@ describe('ApiRepo', function() {
            // The test uses the fake protoc, so it just echoes its args
            var want = '--python_out=' + path.join(
                repo.outDir, 'python');
-           want += ' --grpc_out=' + path.join(
+           want += ' --grpc_python_out=' + path.join(
                repo.outDir, 'python');
            want += ' -I.';
            want += ' -I/an/include/path';

--- a/test/fixtures/fake_protoc
+++ b/test/fixtures/fake_protoc
@@ -25,6 +25,8 @@ main() {
     local out_dir=$(echo "$@" | sed 's/.*--grpc_out=\([^ ]*\).*/\1/')
     # fix out_dir in case protoc was run for the go plugin
     local out_dir=$(echo "$out_dir" | sed 's/.*--go_out=plugins=grpc:\([^ ]*\).*/\1/')
+    # fix out_dir in case protoc was run for the python plugin
+    local out_dir=$(echo "$out_dir" | sed 's/.*--grpc_python_out=\([^ ]*\).*/\1/')
     echo "out_dir is $out_dir" 1>&2;
     local out_proto_path=${out_dir}/$proto_path
     local out_parent=$(dirname $out_proto_path)


### PR DESCRIPTION
* Use --grpc_python_out argument for Python, per https://github.com/grpc/grpc/issues/7857#issuecomment-243503869.
* Ensure that `gen-api-package` returns a non-zero status code when it fails (needed for remote pipeline to properly report a failure)
