### PR TITLE
Python depends on grpcio, rather than grpc.

### DIFF
--- a/config/common_protos.yml
+++ b/config/common_protos.yml
@@ -33,4 +33,4 @@ packages:
     version: ''
 
 # semver is the semantic version of the common protos package.
-semver: 1.3.0
+semver: 1.3.1

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -67,7 +67,7 @@ protobuf:
 
 googleapis_common_protos:
   python:
-    version: '1.2.0'
+    version: '1.3.1'
   ruby:
     version: '1.2.0'
 

--- a/templates/commonpb/python/setup.py.mustache
+++ b/templates/commonpb/python/setup.py.mustache
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
   'protobuf>={{{dependencies.protobuf.python.version}}}',
-  'grpc>={{{dependencies.grpc.python.version}}}'
+  'grpcio>={{{dependencies.grpc.python.version}}}'
 ]
 
 setuptools.setup(


### PR DESCRIPTION
See for historical context:
https://bitbucket.org/seewind/grpc/issues/1/naming-collision-with-grpc-grpc

Updates https://github.com/GoogleCloudPlatform/gcloud-python/issues/2238