### PR TITLE
Make grpcio dep optional for Python googleapis-common-protos

### DIFF
--- a/config/common_protos.yml
+++ b/config/common_protos.yml
@@ -33,4 +33,4 @@ packages:
     version: ''
 
 # semver is the semantic version of the common protos package.
-semver: 1.3.1
+semver: 1.3.2

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -67,7 +67,7 @@ protobuf:
 
 googleapis_common_protos:
   python:
-    version: '1.3.1'
+    version: '1.3.2'
   ruby:
     version: '1.2.0'
 

--- a/templates/commonpb/python/setup.py.mustache
+++ b/templates/commonpb/python/setup.py.mustache
@@ -10,9 +10,12 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
-  'protobuf>={{{dependencies.protobuf.python.version}}}',
-  'grpcio>={{{dependencies.grpc.python.version}}}'
+  'protobuf>={{{dependencies.protobuf.python.version}}}'
 ]
+
+extras_require = {
+  'grpc': ['grpcio>={{{dependencies.grpc.python.version}}}']
+}
 
 setuptools.setup(
   name='{{{api.name}}}',
@@ -31,6 +34,7 @@ setuptools.setup(
   description='Common protobufs used in Google APIs',
   long_description=open('README.rst').read(),
   install_requires=install_requires,
+  extras_require=extras_require,
   license='{{{api.license}}}',
   packages=find_packages(),
   namespace_packages=[{{#api.nsPackages}}'{{{.}}}', {{/api.nsPackages}}],

--- a/templates/python/setup.py.mustache
+++ b/templates/python/setup.py.mustache
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>={{{dependencies.auth.python.version}}}',
   'grpcio>={{{dependencies.grpc.python.version}}}',
-  'googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}'
+  'googleapis-common-protos[grpc]>={{{dependencies.googleapis_common_protos.python.version}}}'
 ]
 
 setuptools.setup(

--- a/test/fixtures/python/setup.py
+++ b/test/fixtures/python/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>=0.4.1',
   'grpcio>=0.15.0',
-  'googleapis-common-protos>=1.2.0'
+  'googleapis-common-protos[grpc]>=1.2.0'
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Updates https://github.com/GoogleCloudPlatform/gcloud-python/issues/2117

NB I deliberately did not add the optional `[grpc]` dependency to the `gax-google-*` packages. They'll currently get `grpcio` transitively from the `grpc-google-*` packages, and I'm thinking forward to when `gax-google-*` might also support HTTP/JSON (and thus not need a gRPC dependency).