### PR TITLE
NodeJS fix -- glob.glob returns the relative path.

### DIFF
--- a/lib/packager.js
+++ b/lib/packager.js
@@ -409,9 +409,10 @@ function makeNodejsPackage(opts, done) {
       opts.packageInfo.serviceAddressName = opts.packageInfo.apiFiles[0].name;
       // Creating a task to bring index.js into the same directory where
       // other generated .js files exist.
-      tasks.push(expand(path.join(opts.templateDir, 'index.js.mustache'),
-                        path.join(path.dirname(jsFiles[0]), 'index.js'),
-                        opts.packageInfo));
+      tasks.push(expand(
+          path.join(opts.templateDir, 'index.js.mustache'),
+          path.join(opts.top, path.dirname(jsFiles[0]), 'index.js'),
+          opts.packageInfo));
     }
     opts.packageInfo.singleFile = (opts.packageInfo.apiFiles.length === 1);
     async.series(tasks, function(err) {
@@ -429,7 +430,7 @@ function makeNodejsPackage(opts, done) {
   if (opts.mockApiFilesForTest) {
     // For tests, mock data is passed instead of scanning the filesystem.
     runTask(null, _.map(opts.mockApiFilesForTest, function(file) {
-      return path.join(opts.top, 'src', file);
+      return path.join('src', file);
     }));
   } else {
     glob.glob('src/**/*_api.js', {cwd: opts.top}, runTask);


### PR DESCRIPTION
The test succeeded unexpectedly because the test code handles
the data in a different way. Fixed both of them.