### PR TITLE
Update nodejs gax template.

### DIFF
--- a/templates/gax/nodejs/index.js.mustache
+++ b/templates/gax/nodejs/index.js.mustache
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/templates/gax/nodejs/src/index.js.mustache
+++ b/templates/gax/nodejs/src/index.js.mustache
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
 module.exports.{{{api.version}}} = require('./{{{api.version}}}');

--- a/test/fixtures/gax/nodejs/src/index.js
+++ b/test/fixtures/gax/nodejs/src/index.js
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
 module.exports.v2 = require('./v2');

--- a/test/fixtures/gax/nodejs/src/v2/index.js
+++ b/test/fixtures/gax/nodejs/src/v2/index.js
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- 'use strict' is unnecessary but better to exist.
- it's better to avoid starting the license comment with /**