### PR TITLE
Add upper bound logic to Python packages

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -30,6 +30,6 @@ semver:
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.9.0'
+  python: '0.9.1'
   ruby: '0.6.8'
   php: '0.6.0'

--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -30,6 +30,6 @@ semver:
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.9.1'
+  python: '0.9.2'
   ruby: '0.6.8'
   php: '0.6.0'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -19,6 +19,7 @@
 auth:
   python:
     version: '1.4.11'
+    next_version: '2.0.0'
   ruby:
     version: '0.5.1'
   nodejs:
@@ -35,6 +36,7 @@ grpc:
       deployment_target: '10.8'
   python:
     version: '1.0.0'
+    next_version: '2.0.0'
   ruby:
     version: '1.0'
   nodejs:
@@ -46,8 +48,8 @@ grpc:
 
 gax:
   python:
-    version: '0.12.5'
-    next_version: '0.13.0'
+    version: '0.13.0'
+    next_version: '0.14.0'
   ruby:
     version: '0.5.1'
   nodejs:
@@ -56,6 +58,7 @@ gax:
 protobuf:
   python:
     version: '3.0.0'
+    next_version: '4.0.0'
   ruby:
     version: '3.0'
   nodejs:
@@ -68,6 +71,7 @@ protobuf:
 googleapis_common_protos:
   python:
     version: '1.3.4'
+    next_version: '2.0.0'
   ruby:
     version: '1.3.1'
   nodejs:

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -382,7 +382,7 @@ function makeNodejsPackage(opts, done) {
     var dstBase = removeMustacheExt(f);
     var tmpl = path.join(opts.templateDir, f);
     var dst = path.join(opts.top, dstBase);
-    // index.js should reside among other .js files for GAX packages.
+    // index.js should reside among other .js files for GAPIC packages.
     if (dstBase !== 'index.js') {
       tasks.push(expand(tmpl, dst, opts.packageInfo));
     }

--- a/templates/gax/python/README.rst.mustache
+++ b/templates/gax/python/README.rst.mustache
@@ -1,4 +1,4 @@
-GAX library for the Google {{{api.titlename}}} API
+GAPIC library for the Google {{{api.titlename}}} API
 ================================================================================
 
 {{{api.name}}}-{{{api.version}}} uses google-gax_ (Google API extensions) to provide an

--- a/templates/gax/python/docs/conf.py.mustache
+++ b/templates/gax/python/docs/conf.py.mustache
@@ -281,7 +281,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   (master_doc, '{{api.name}}-{{api.version}}', u'{{api.name}}-{{api.version}} Documentation',
-   author, '{{api.name}}-{{api.version}}', 'GAX library for the {{api.simplename}} (api.version) service',
+   author, '{{api.name}}-{{api.version}}', 'GAPIC library for the {{api.simplename}} (api.version) service',
    'APIs'),
 ]
 

--- a/templates/gax/python/docs/index.rst.mustache
+++ b/templates/gax/python/docs/index.rst.mustache
@@ -1,7 +1,7 @@
 .. {{api.name}}-{{api.version}} sphinx documentation master file
 
 
-GAX library for the Google {{api.titlename}} API
+GAPIC library for the Google {{api.titlename}} API
 =============================================================================================================
 
 This is the API documentation for ``{{api.name}}-{{api.version}}``.

--- a/templates/gax/python/requirements.txt.mustache
+++ b/templates/gax/python/requirements.txt.mustache
@@ -1,4 +1,5 @@
-googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}
+googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}, <{{{dependencies.googleapis_common_protos.python.next_version}}}
 google-gax>={{{dependencies.gax.python.version}}}, <{{{dependencies.gax.python.next_version}}}
+# TODO (https://github.com/googleapis/packman/issues/119): need upper bound logic
 {{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}
-oauth2client>={{{dependencies.auth.python.version}}}
+oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}

--- a/templates/gax/python/setup.py.mustache
+++ b/templates/gax/python/setup.py.mustache
@@ -9,10 +9,11 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}',
+    'googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}, <{{{dependencies.googleapis_common_protos.python.next_version}}}',
     'google-gax>={{{dependencies.gax.python.version}}}, <{{{dependencies.gax.python.next_version}}}',
+    # TODO: need upper bound logic
     '{{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}',
-    'oauth2client>={{{dependencies.auth.python.version}}}',
+    'oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}',
 ]
 
 setup(

--- a/templates/gax/python/setup.py.mustache
+++ b/templates/gax/python/setup.py.mustache
@@ -11,7 +11,7 @@ import sys
 install_requires = [
     'googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.version}}}, <{{{dependencies.googleapis_common_protos.python.next_version}}}',
     'google-gax>={{{dependencies.gax.python.version}}}, <{{{dependencies.gax.python.next_version}}}',
-    # TODO: need upper bound logic
+    # TODO (https://github.com/googleapis/packman/issues/119): need upper bound logic
     '{{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}',
     'oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}',
 ]

--- a/templates/gax/python/setup.py.mustache
+++ b/templates/gax/python/setup.py.mustache
@@ -1,4 +1,4 @@
-"""A setup module for the GAX {{{api.titlename}}} library.
+"""A setup module for the GAPIC {{{api.titlename}}} library.
 
 See:
 https://packaging.python.org/en/latest/distributing.html
@@ -30,7 +30,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    description='GAX library for the Google {{{api.titlename}}} API',
+    description='GAPIC library for the Google {{{api.titlename}}} API',
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=install_requires,

--- a/templates/python/setup.py.mustache
+++ b/templates/python/setup.py.mustache
@@ -10,9 +10,9 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
-  'oauth2client>={{{dependencies.auth.python.version}}}',
-  'grpcio>={{{dependencies.grpc.python.version}}}',
-  'googleapis-common-protos[grpc]>={{{dependencies.googleapis_common_protos.python.version}}}'
+  'oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}',
+  'grpcio>={{{dependencies.grpc.python.version}}}, <{{{dependencies.grpc.python.next_version}}}',
+  'googleapis-common-protos[grpc]>={{{dependencies.googleapis_common_protos.python.version}}}, <{{{dependencies.googleapis_common_protos.python.next_version}}}'
 ]
 
 setuptools.setup(

--- a/test/fixtures/python/setup.py
+++ b/test/fixtures/python/setup.py
@@ -10,9 +10,9 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
-  'oauth2client>=0.4.1',
-  'grpcio>=0.15.0',
-  'googleapis-common-protos[grpc]>=1.2.0'
+  'oauth2client>=0.4.1, <0.5.0',
+  'grpcio>=0.15.0, <0.16.0',
+  'googleapis-common-protos[grpc]>=1.2.0, <2.0.0'
 ]
 
 setuptools.setup(

--- a/test/packager.js
+++ b/test/packager.js
@@ -135,7 +135,8 @@ var testPackageInfo = {
     },
     googleapis_common_protos: {
       python: {
-        version: '1.2.0'
+        version: '1.2.0',
+        next_version: '2.0.0'
       },
       ruby: {
         version: '3.0.0b1.1'
@@ -169,7 +170,8 @@ var testPackageInfo = {
         version: '0.5.0'
       },
       python: {
-        version: '0.15.0'
+        version: '0.15.0',
+        next_version: '0.16.0'
       },
       ruby: {
         version: '0.9.3'
@@ -180,7 +182,8 @@ var testPackageInfo = {
     },
     auth: {
       python: {
-        version: '0.4.1'
+        version: '0.4.1',
+        next_version: '0.5.0'
       },
       ruby: {
         version: '0.4.1'


### PR DESCRIPTION
* Added upper-bounds to most packages, except our `grpc-google-*` packages, which require a bit more logic (https://github.com/googleapis/packman/issues/119).
* Protects us against future breaking changes in our dependencies