### PR TITLE
Bump Python to 0.10.0, and GAX dependency to 0.14.1

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -30,6 +30,6 @@ semver:
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.9.2'
+  python: '0.10.0'
   ruby: '0.6.8'
   php: '0.6.0'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -48,8 +48,8 @@ grpc:
 
 gax:
   python:
-    version: '0.13.0'
-    next_version: '0.14.0'
+    version: '0.14.1'
+    next_version: '0.15.0'
   ruby:
     version: '0.5.1'
   nodejs:


### PR DESCRIPTION
Self-approving these version bumps. FYI @geigerj 