### PR TITLE
Remove oauth2client upper-bound.

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -19,7 +19,6 @@
 auth:
   python:
     version: '1.4.11'
-    next_version: '2.0.0'
   ruby:
     version: '0.5.1'
   nodejs:

--- a/templates/gax/python/requirements.txt.mustache
+++ b/templates/gax/python/requirements.txt.mustache
@@ -2,4 +2,4 @@ googleapis-common-protos>={{{dependencies.googleapis_common_protos.python.versio
 google-gax>={{{dependencies.gax.python.version}}}, <{{{dependencies.gax.python.next_version}}}
 # TODO (https://github.com/googleapis/packman/issues/119): need upper bound logic
 {{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}
-oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}
+oauth2client>={{{dependencies.auth.python.version}}}

--- a/templates/gax/python/setup.py.mustache
+++ b/templates/gax/python/setup.py.mustache
@@ -13,7 +13,7 @@ install_requires = [
     'google-gax>={{{dependencies.gax.python.version}}}, <{{{dependencies.gax.python.next_version}}}',
     # TODO (https://github.com/googleapis/packman/issues/119): need upper bound logic
     '{{{api.dependsOn}}}-{{{api.version}}}>={{{api.semantic_version}}}',
-    'oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}',
+    'oauth2client>={{{dependencies.auth.python.version}}}',
 ]
 
 setup(

--- a/templates/python/setup.py.mustache
+++ b/templates/python/setup.py.mustache
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 install_requires = [
   'oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}',
   'grpcio>={{{dependencies.grpc.python.version}}}, <{{{dependencies.grpc.python.next_version}}}',
-  'googleapis-common-protos[grpc]>={{{dependencies.googleapis_common_protos.python.version}}}, <{{{dependencies.googleapis_common_protos.python.next_version}}}'
+  'googleapis-common-protos[grpc]>={{{dependencies.googleapis_common_protos.python.version}}}'
 ]
 
 setuptools.setup(

--- a/templates/python/setup.py.mustache
+++ b/templates/python/setup.py.mustache
@@ -10,9 +10,9 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
-  'oauth2client>={{{dependencies.auth.python.version}}}, <{{{dependencies.auth.python.next_version}}}',
+  'oauth2client>={{{dependencies.auth.python.version}}}',
   'grpcio>={{{dependencies.grpc.python.version}}}, <{{{dependencies.grpc.python.next_version}}}',
-  'googleapis-common-protos[grpc]>={{{dependencies.googleapis_common_protos.python.version}}}'
+  'googleapis-common-protos[grpc]>={{{dependencies.googleapis_common_protos.python.version}}}, <{{{dependencies.googleapis_common_protos.python.next_version}}}'
 ]
 
 setuptools.setup(

--- a/test/fixtures/python/setup.py
+++ b/test/fixtures/python/setup.py
@@ -10,7 +10,7 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
-  'oauth2client>=0.4.1, <0.5.0',
+  'oauth2client>=0.4.1',
   'grpcio>=0.15.0, <0.16.0',
   'googleapis-common-protos[grpc]>=1.2.0, <2.0.0'
 ]

--- a/test/packager.js
+++ b/test/packager.js
@@ -183,7 +183,6 @@ var testPackageInfo = {
     auth: {
       python: {
         version: '0.4.1',
-        next_version: '0.5.0'
       },
       ruby: {
         version: '0.4.1'

--- a/test/packager.js
+++ b/test/packager.js
@@ -182,7 +182,7 @@ var testPackageInfo = {
     },
     auth: {
       python: {
-        version: '0.4.1',
+        version: '0.4.1'
       },
       ruby: {
         version: '0.4.1'


### PR DESCRIPTION
google-cloud-pyton is effectively using version 3.0.0 anyway. Having
this upper bound causes version conflicts, so it was doing more harm
than good.