### PR TITLE
Remove the trailing comma if singleFile.

### DIFF
--- a/templates/gax/nodejs/package.json.mustache
+++ b/templates/gax/nodejs/package.json.mustache
@@ -12,7 +12,7 @@
     "arguejs": "^{{{dependencies.nodeModules.arguejs.version}}}",
     "google-proto-files": "^{{{dependencies.googleapis_common_protos.nodejs.version}}}",
     "google-gax": "^{{{dependencies.gax.nodejs.version}}}",
-    "extend": "^{{{dependencies.nodeModules.extend.version}}}",{{^singleFile}}
+    "extend": "^{{{dependencies.nodeModules.extend.version}}}"{{^singleFile}},
     "lodash.union": "^{{{dependencies.nodeModules.lodash.version}}}",{{/singleFile}}
   },
   "license": "{{{api.license}}}",


### PR DESCRIPTION
lodash.union will be added only when there are multiple services
in the API, but the template is wrong so that the trailing comma
is included in the dependency list if single service API, which
leads to an invalid JSON.