### PR TITLE
Fix nodejs generation of index.js

### DIFF
--- a/templates/gax/nodejs/index.js.mustache
+++ b/templates/gax/nodejs/index.js.mustache
@@ -30,7 +30,7 @@ function {{{api.version}}}(options) {
   }, options);
   var gaxGrpc = gax.grpc(options);
   {{#singleFile}}
-  return {{{apiFiles[0].name}}}(gaxGrpc);
+  return {{{apiFiles.0.name}}}(gaxGrpc);
   {{/singleFile}}
   {{^singleFile}}
   var result = {};

--- a/test/fixtures/gax/nodejs-single/nodejs/package.json
+++ b/test/fixtures/gax/nodejs-single/nodejs/package.json
@@ -1,0 +1,21 @@
+{
+  "url": "https://github.com/google/googleapis",
+  "name": "@google-cloud/unittest",
+  "version": "1.0.0",
+  "author": "Google Inc.",
+  "description": "Packager Unittest library for Node.js",
+  "main": "src/index.js",
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "arguejs": "^0.2.3",
+    "google-proto-files": "^0.7.0",
+    "google-gax": "^0.7.0",
+    "extend": "^3.0.0"
+  },
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=0.12.0"
+  }
+}

--- a/test/fixtures/gax/nodejs-single/nodejs/src/v2/index.js
+++ b/test/fixtures/gax/nodejs-single/nodejs/src/v2/index.js
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var fooApi = require('./foo_api');
+var gax = require('google-gax');
+var extend = require('extend');
+
+function v2(options) {
+  options = extend({
+    scopes: v2.ALL_SCOPES
+  }, options);
+  var gaxGrpc = gax.grpc(options);
+  return fooApi(gaxGrpc);
+}
+v2.SERVICE_ADDRESS = fooApi.SERVICE_ADDRESS;
+v2.ALL_SCOPES = fooApi.ALL_SCOPES;
+module.exports = v2;

--- a/test/packager.js
+++ b/test/packager.js
@@ -414,6 +414,30 @@ describe('the nodejs package builder', function() {
     };
     async.series([packager.nodejs.bind(null, opts), checkExpanded], done);
   });
+
+  it('should construct a gax package for single service API', function(done) {
+    var packageInfo = _.cloneDeep(testPackageInfo);
+    // Specifies the style of package name / title name, which should be set in
+    // lib/api_repo.js
+    packageInfo.api.name = '@google-cloud/unittest';
+    packageInfo.api.titlename = 'Packager Unittest';
+    var opts = _.merge({
+      packageInfo: packageInfo,
+      top: path.join(top, 'nodejs')
+    }, {templateDir: path.join(__dirname, '..', 'templates', 'gax', 'nodejs')});
+    opts.mockApiFilesForTest = ['v2/foo_api.js'];
+    var expanded = [
+      'nodejs/package.json',
+      'nodejs/src/v2/index.js'
+    ];
+    var compareWithFixture = genFixtureCompareFunc(
+        top, ['gax', 'nodejs-single']);
+    var checkExpanded = function checkExpanded(next) {
+      var expandTasks = _.map(expanded, compareWithFixture);
+      async.parallel(expandTasks, next);
+    };
+    async.series([packager.nodejs.bind(null, opts), checkExpanded], done);
+  });
 });
 
 describe('the java package builder', function() {


### PR DESCRIPTION
- mustache does not allow accessing through square brackets.
  . with number (.0) works fine.
- added test case to verify this and #131.