### PR TITLE
Fixed typo in python publishing readme.

### DIFF
--- a/templates/python/PUBLISHING.rst
+++ b/templates/python/PUBLISHING.rst
@@ -14,16 +14,14 @@ PREREQUISITES
 
 TO PUBLISH
 ----------
-`
+
 - Make sure you have `an account`_ on pypi_.
 - Publish your package as described in `Packaging and Distributing Projects`_.
 
 E.g,
 
-##
-
   $ python setup.py sdist register upload
 
-_`Packaging and Distributing projects`: https://packaging.python.org/en/latest/distributing.html#uploading-your-project-to-pypi
-_`an account`: https://pypi.python.org/pypi?%3Aaction=register_form
-_pypi: http://pypi.python.org
+.. _`Packaging and Distributing projects`: https://packaging.python.org/en/latest/distributing.html#uploading-your-project-to-pypi
+.. _`an account`: https://pypi.python.org/pypi?%3Aaction=register_form
+.. _pypi: http://pypi.python.org

--- a/templates/python/PUBLISHING.rst
+++ b/templates/python/PUBLISHING.rst
@@ -9,7 +9,7 @@ contents since it was created.
 PREREQUISITES
 -------------
 
-- Python must installed
+- Python must be installed
 
 
 TO PUBLISH

--- a/templates/python/PUBLISHING.rst
+++ b/templates/python/PUBLISHING.rst
@@ -9,14 +9,14 @@ contents since it was created.
 PREREQUISITES
 -------------
 
-- Python must be installed
+- Python must be installed.
 
 
 TO PUBLISH
 ----------
-
+`
 - Make sure you have `an account`_ on pypi_.
-- Publish your package as described in `Packaging and Distributing Projects`_
+- Publish your package as described in `Packaging and Distributing Projects`_.
 
 E.g,
 


### PR DESCRIPTION
Grammar fix as pointed out in [googleapis/api-client-staging/pull/21](https://github.com/googleapis/api-client-staging/pull/21)