### PR TITLE
Don't HTML encode in Python doc templates

### DIFF
--- a/templates/gax/python/docs/conf.py.mustache
+++ b/templates/gax/python/docs/conf.py.mustache
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# {{api.name}}-{{api.version}} documentation build configuration file
+# {{{api.name}}}-{{{api.version}}} documentation build configuration file
 #
 # This file is execfile()d with the current directory set to its
 # containing dir.
@@ -20,7 +20,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '{{api.semantic_version}}'
+__version__ = '{{{api.semantic_version}}}'
 
 # -- General configuration ------------------------------------------------
 
@@ -60,7 +60,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'{{api.name}}-{{api.version}}'
+project = u'{{{api.name}}}-{{{api.version}}}'
 copyright = u'2016, Google'
 author = u'Google APIs'
 
@@ -214,7 +214,7 @@ html_theme = 'sphinx_rtd_theme'
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '{{api.name}}-{{api.version}}-doc'
+htmlhelp_basename = '{{{api.name}}}-{{{api.version}}}-doc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -236,7 +236,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, '{{api.name}}-{{api.version}}.tex', u'{{api.name}}-{{api.version}} Documentation',
+  (master_doc, '{{{api.name}}}-{{{api.version}}}.tex', u'{{{api.name}}}-{{{api.version}}} Documentation',
    author, 'manual'),
 ]
 
@@ -266,7 +266,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, '{{api.name}}-{{api.version}}', u'{{api.name}}-{{api.version}} Documentation',
+    (master_doc, '{{{api.name}}}-{{{api.version}}}', u'{{{api.name}}}-{{{api.version}}} Documentation',
      [author], 1)
 ]
 
@@ -280,8 +280,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, '{{api.name}}-{{api.version}}', u'{{api.name}}-{{api.version}} Documentation',
-   author, '{{api.name}}-{{api.version}}', 'GAPIC library for the {{api.simplename}} (api.version) service',
+  (master_doc, '{{{api.name}}}-{{{api.version}}}', u'{{{api.name}}}-{{{api.version}}} Documentation',
+   author, '{{{api.name}}}-{{{api.version}}}', 'GAPIC library for the {{{api.simplename}}} (api.version) service',
    'APIs'),
 ]
 

--- a/templates/gax/python/docs/index.rst.mustache
+++ b/templates/gax/python/docs/index.rst.mustache
@@ -1,18 +1,18 @@
-.. {{api.name}}-{{api.version}} sphinx documentation master file
+.. {{{api.name}}}-{{{api.version}}} sphinx documentation master file
 
 
-GAPIC library for the Google {{api.titlename}} API
+GAPIC library for the Google {{{api.titlename}}} API
 =============================================================================================================
 
-This is the API documentation for ``{{api.name}}-{{api.version}}``.
+This is the API documentation for ``{{{api.name}}}-{{{api.version}}}``.
 
-{{api.name}}-{{api.version}} uses google-gax_ (Google API extensions) to provide an
-easy-to-use client library for the `Google {{api.titlename}} API`_ ({{api.version}}) defined in the googleapis_ git repository
+{{{api.name}}}-{{{api.version}}} uses google-gax_ (Google API extensions) to provide an
+easy-to-use client library for the `Google {{{api.titlename}}} API`_ ({{{api.version}}}) defined in the googleapis_ git repository
 
 
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/{{api.path}}/{{api.version}}
-.. _`Google {{api.titlename}} API`: https://developers.google.com/apis-explorer/?hl=en_US#p/{{api.shortname}}/{{api.version}}/
+.. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/{{{api.path}}}/{{{api.version}}}
+.. _`Google {{{api.titlename}}} API`: https://developers.google.com/apis-explorer/?hl=en_US#p/{{{api.shortname}}}/{{{api.version}}}/
 
 
 APIs

--- a/templates/gax/python/docs/starting.rst.mustache
+++ b/templates/gax/python/docs/starting.rst.mustache
@@ -1,9 +1,9 @@
 Getting started
 ===============
 
-{{api.name}}-{{api.version}} will allow you to connect to the `Google {{api.titlename}} API`_ and access all its methods. In order to achieve this, you need to set up authentication as well as install the library locally.
+{{{api.name}}}-{{{api.version}}} will allow you to connect to the `Google {{{api.titlename}}} API`_ and access all its methods. In order to achieve this, you need to set up authentication as well as install the library locally.
 
-.. _`Google {{api.titlename}} API`: https://developers.google.com/apis-explorer/?hl=en_US#p/{{api.shortname}}/{{api.version}}/
+.. _`Google {{{api.titlename}}} API`: https://developers.google.com/apis-explorer/?hl=en_US#p/{{{api.shortname}}}/{{{api.version}}}/
 
 
 Installation
@@ -29,7 +29,7 @@ Mac/Linux
     pip install virtualenv
     virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install {{api.name}}-{{api.version}}
+    <your-env>/bin/pip install {{{api.name}}}-{{{api.version}}}
 
 Windows
 ~~~~~~~
@@ -39,7 +39,7 @@ Windows
     pip install virtualenv
     virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install {{api.name}}-{{api.version}}
+    <your-env>\Scripts\pip.exe install {{{api.name}}}-{{{api.version}}}
 
 
 Using the API


### PR DESCRIPTION
This results in, for example, bad URL links.