### PR TITLE
Update the gax/nodejs template.

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -53,7 +53,7 @@ gax:
   ruby:
     version: '0.5.1'
   nodejs:
-    version: '0.6.0'
+    version: '0.7.0'
 
 protobuf:
   python:
@@ -79,8 +79,6 @@ googleapis_common_protos:
 
 # nodejs-specific dependencies.
 nodeModules:
-  arguejs:
-    version: '0.2.3'
   extend:
     version: '3.0.0'
   lodash:

--- a/templates/gax/nodejs/package.json.mustache
+++ b/templates/gax/nodejs/package.json.mustache
@@ -9,7 +9,6 @@
     "src"
   ],
   "dependencies": {
-    "arguejs": "^{{{dependencies.nodeModules.arguejs.version}}}",
     "google-proto-files": "^{{{dependencies.googleapis_common_protos.nodejs.version}}}",
     "google-gax": "^{{{dependencies.gax.nodejs.version}}}",
     "extend": "^{{{dependencies.nodeModules.extend.version}}}"{{^singleFile}},

--- a/test/fixtures/gax/nodejs-single/nodejs/package.json
+++ b/test/fixtures/gax/nodejs-single/nodejs/package.json
@@ -9,7 +9,6 @@
     "src"
   ],
   "dependencies": {
-    "arguejs": "^0.2.3",
     "google-proto-files": "^0.7.0",
     "google-gax": "^0.7.0",
     "extend": "^3.0.0"

--- a/test/fixtures/gax/nodejs/package.json
+++ b/test/fixtures/gax/nodejs/package.json
@@ -9,7 +9,6 @@
     "src"
   ],
   "dependencies": {
-    "arguejs": "^0.2.3",
     "google-proto-files": "^0.7.0",
     "google-gax": "^0.7.0",
     "extend": "^3.0.0",


### PR DESCRIPTION
- the new codegen relies on gax-nodejs 0.7.0 --
  updating the package version
- arguejs is not used anymore in the new codegen.