### PR TITLE
Bump Python version

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -30,6 +30,6 @@ semver:
   #       publishing some 1.0.x versions to pypi already. They are now
   #       deleted but files still exist on the pypi servers and can prevent
   #       us from using the version number again.
-  python: '0.10.0'
+  python: '0.11.0'
   ruby: '0.6.8'
   php: '0.6.0'


### PR DESCRIPTION
Breaking change in enum handling, so bump minor version.