### PR TITLE
Bump googleapis-common-protos version

### DIFF
--- a/config/common_protos.yml
+++ b/config/common_protos.yml
@@ -33,4 +33,4 @@ packages:
     version: ''
 
 # semver is the semantic version of the common protos package.
-semver: 1.3.4
+semver: 1.3.5

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -70,7 +70,7 @@ protobuf:
 
 googleapis_common_protos:
   python:
-    version: '1.3.4'
+    version: '1.3.5'
     next_version: '2.0.0dev'
   ruby:
     version: '1.3.1'


### PR DESCRIPTION
Have some updates to LRO and HTTP request.

PR for updating this package is separate: https://github.com/googleapis/api-client-staging/pull/50