### PR TITLE
Update google protos version.

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -75,7 +75,7 @@ googleapis_common_protos:
   ruby:
     version: '1.3.1'
   nodejs:
-    version: '0.7.0'
+    version: '0.8.2'
 
 # nodejs-specific dependencies.
 nodeModules:


### PR DESCRIPTION
Theres a typo on 0.7.0 that causes errors for monitoring.