### PR TITLE
Support resource name generation for gRPC in Java

### DIFF
--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -233,6 +233,14 @@ var parseArgs = function parseArgs() {
       dest: 'protoGenPackageDeps'
     }
   );
+  cli.addArgument(
+    [ '--gapic_yaml' ],
+    {
+      help: 'Specifies the gapic yaml, which is required\n' +
+            + ' for resource name generation.',
+      dest: 'gapicYaml'
+    }
+  );
   return cli.parseArgs();
 };
 

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -83,3 +83,7 @@ nodeModules:
     version: '3.0.0'
   lodash:
     version: '4.6.0'
+
+api-common:
+  java:
+    version: '0.0.2'

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -252,6 +252,9 @@ ApiRepo.prototype.buildPackages =
                     return that.pkgPrefix + dep;
                   });
             }
+            if (that.opts.gapicYaml) {
+              opts.packageInfo.api.gapicYaml = that.opts.gapicYaml;
+            }
             packager[l](opts, next);
           };
           makePackageTasks.push(buildAPackage);

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -328,6 +328,14 @@ function makeJavaPackage(opts, done) {
     tasks.push(checkedCopy(src, dst));
   });
 
+  if (opts.packageInfo.api.gapicYaml) {
+    var basename = path.basename(opts.packageInfo.api.gapicYaml);
+    var src = opts.packageInfo.api.gapicYaml;
+    var dst = path.join(opts.top, basename);
+    tasks.push(checkedCopy(src, dst));
+    opts.packageInfo.api.gapicYaml = basename;
+  }
+
   // Move the expanded files to the top-level dir.
   opts.templates.forEach(function(f) {
     var dstBase = removeMustacheExt(f);

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -28,6 +28,16 @@ dependencies {
   compile "com.google.api.grpc:{{{.}}}:{{{api.semantic_version}}}"
   {{/api.protoGenPackageDeps}}
   compile "io.grpc:grpc-all:{{{dependencies.grpc.java.version}}}"
+  compile "com.google.api:api-common:{{{dependencies.api-common.java.version}}}"
+}
+
+ext.locateGapicPluginMethod = { ->
+  def outstream = new ByteArrayOutputStream()
+  exec {
+    commandLine 'which', 'gapic_plugin.py'
+    standardOutput = outstream
+  }
+  return outstream.toString().trim()
 }
 
 protobuf {
@@ -41,11 +51,18 @@ protobuf {
     grpc {
       artifact = 'io.grpc:protoc-gen-grpc-java:{{{dependencies.grpc.java.version}}}'
     }
+    gapic {
+      path = locateGapicPluginMethod()
+    }
   }
   generateProtoTasks {
     all()*.plugins {
       grpc {
         outputSubDir = 'java'
+      }
+      gapic {
+        outputSubDir = 'java'
+        option '{{{api.gapicYaml}}}'
       }
     }
   }


### PR DESCRIPTION
- Adds a new command line argument to accept the gapic yaml file
- Updates the generated build.gradle file with the gapic yaml and resource name plugin