### PR TITLE
Update java

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -24,7 +24,7 @@ license: Apache-2.0
 semver:
   go: '0.6.0'
   objc: '0.6.0'
-  java: '0.1.0'
+  java: '0.1.3'
   nodejs: '0.7.1'
   # TODO: Python must go to 1.0.20 or 1.1.0 when we GA, due to mistakenly
   #       publishing some 1.0.x versions to pypi already. They are now

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -254,6 +254,7 @@ ApiRepo.prototype.buildPackages =
             }
             if (that.opts.gapicYaml) {
               opts.packageInfo.api.gapicYaml = that.opts.gapicYaml;
+              opts.packageInfo.api.useGapicPlugin = true;
             }
             packager[l](opts, next);
           };

--- a/templates/java/build-alt.gradle.mustache
+++ b/templates/java/build-alt.gradle.mustache
@@ -51,19 +51,23 @@ protobuf {
     grpc {
       artifact = 'io.grpc:protoc-gen-grpc-java:{{{dependencies.grpc.java.version}}}'
     }
+    {{#api.useGapicPlugin}}
     gapic {
       path = locateGapicPluginMethod()
     }
+    {{/api.useGapicPlugin}}
   }
   generateProtoTasks {
     all()*.plugins {
       grpc {
         outputSubDir = 'java'
       }
+      {{#api.useGapicPlugin}}
       gapic {
         outputSubDir = 'java'
         option '{{{api.gapicYaml}}}'
       }
+      {{/api.useGapicPlugin}}
     }
   }
 }


### PR DESCRIPTION
- Bump Java gRPC package semantic version
- Support Java gRPC generation when no gapic yaml is provided, as per common protos